### PR TITLE
The legal.txt should actually contain the company name. Removed helper p...

### DIFF
--- a/tclapp/mycompany/template/doc/legal.txt
+++ b/tclapp/mycompany/template/doc/legal.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2014, Xilinx
+Copyright (c) 2014, mycompany
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/tclapp/mycompany/template/tclIndex
+++ b/tclapp/mycompany/template/tclIndex
@@ -9,3 +9,4 @@
 set auto_index(::tclapp::mycompany::template::my_command2) [list source [file join $dir myscript2.tcl]]
 set auto_index(::tclapp::mycompany::template::my_command3) [list source [file join $dir myscript2.tcl]]
 set auto_index(::tclapp::mycompany::template::my_command1) [list source [file join $dir myscript1.tcl]]
+


### PR DESCRIPTION
...rocs from tclIndex for correct catalog generation
