### PR TITLE
Added filtering capability for the check_cdc_paths proc [2]

### DIFF
--- a/tclapp/xilinx/designutils/check_cdc_paths.tcl
+++ b/tclapp/xilinx/designutils/check_cdc_paths.tcl
@@ -40,7 +40,7 @@ proc ::tclapp::xilinx::designutils::check_cdc_paths::check_cdc_paths {args} {
 	## Parse arguments from option command line
 	while {[string match -* [lindex $args 0]]} {
         switch -regexp -- [lindex $args 0] {
-			{-n(o(_(r(e(s(e(t(_(p(a(t(h)?)?)?)?)?)?)?)?)?)?)?)?$}  { set opts(-no_reset_paths) 1}
+			{-n(o(_(r(e(s(e(t(_(p(a(t(h(s)?)?)?)?)?)?)?)?)?)?)?)?)?$}  { set opts(-no_reset_paths) 1}
              default {
                 return -code error "ERROR: \[check_cdc_paths\] Unknown option '[lindex $args 0]', please type 'check_cdc_paths -help' for usage info."
             }

--- a/tclapp/xilinx/designutils/doc/legal.txt
+++ b/tclapp/xilinx/designutils/doc/legal.txt
@@ -16,3 +16,4 @@ All contributors must date and digitally sign once below in order to submit to t
 <YYYYMMDD Date>::<github id>::<Full Name>
 =================================================================================================
 20140221::dpefour::David Pefourque
+20140325::ronagyl::Laszlo Nagy

--- a/tclapp/xilinx/designutils/test/check_cdc_paths_0002.tcl
+++ b/tclapp/xilinx/designutils/test/check_cdc_paths_0002.tcl
@@ -1,0 +1,27 @@
+# Set the File Directory to the current directory location of the script
+set file_dir [file normalize [file dirname [info script]]]
+set unit_test [file rootname [file tail [info script]]]
+
+# Set the Xilinx Tcl App Store Repository to the current repository location
+puts "== Unit Test directory: $file_dir"
+puts "== Unit Test name: $unit_test"
+
+# Set the Name to the name of the script
+set name [file rootname [file tail [info script]]]
+
+# Create in-memory project
+create_project $name -in_memory
+
+add_files -fileset sources_1 "$file_dir/src/bench16/bench16_netlist.v"
+add_files -fileset constrs_1 "$file_dir/src/bench16/bench16.xdc"
+link_design -part xc7k70tfbg484-3 -top bench16
+
+# Run the check_cdc_paths script and verify that no error was reported
+if {[catch { ::tclapp::xilinx::designutils::check_cdc_paths -no_reset_paths} catchErrorString]} {
+    close_project
+    error [format " -E- Unit test $name failed: %s" $catchErrorString]   
+}
+
+close_project
+
+return 0

--- a/tclapp/xilinx/designutils/test/test.tcl
+++ b/tclapp/xilinx/designutils/test/test.tcl
@@ -16,6 +16,7 @@ package require ::tclapp::xilinx::designutils
 # Start the unit tests
 puts "script is invoked from $test_dir"
 source -notrace [file join $test_dir check_cdc_paths_0001.tcl]
+source -notrace [file join $test_dir check_cdc_paths_0002.tcl]
 source -notrace [file join $test_dir convert_muxfx_to_luts_0001.tcl]
 source -notrace [file join $test_dir write_slr_pblock_xdc_0001.tcl]
 


### PR DESCRIPTION
1. added signature
2. fixed typo for the flag
3. added the test file. Unfortunately at this point I did not have any small/public dcp to add it to the test.
