### PR TITLE
Fixing typo in comment header of get_leaf_cells

### DIFF
--- a/tclapp/xilinx/designutils/get_leaf_cells.tcl
+++ b/tclapp/xilinx/designutils/get_leaf_cells.tcl
@@ -5,7 +5,7 @@ namespace eval ::tclapp::xilinx::designutils {
 }
 
 #------------------------------------------------------------------------
-# ::tclapp::xilinx::designutils::report_clock_interaction
+# ::tclapp::xilinx::designutils::get_leaf_cells
 #------------------------------------------------------------------------
 # Proc to export
 #------------------------------------------------------------------------


### PR DESCRIPTION
Header of this comment should read "get_leaf_cells"
