### PR TITLE
rename arguments to simple names instead of - keyword

### DIFF
--- a/tclapp/xilinx/incrcompile/get_non_reused.tcl
+++ b/tclapp/xilinx/incrcompile/get_non_reused.tcl
@@ -8,7 +8,7 @@ proc ::tclapp::xilinx::incrcompile::get_non_reused { object } {
   # Summary : get non reused objects
 
   # Argument Usage:
-  #  object : The object type. The valid values are : -cells -nets -pins -ports -sites
+  #  object : The object type. The valid values are : cells nets pins ports sites
 
   # Return Value:
   # list of non reused objects
@@ -16,26 +16,26 @@ proc ::tclapp::xilinx::incrcompile::get_non_reused { object } {
   # Categories: xilinxtclstore, incrcompile
 
   set ret_values {}
-  if { $object ne "-cells" && $object ne "-nets" && $object ne "-pins" && $object ne "-ports" && $object ne "-sites" } {
-    puts "Error: Illegal value for argument object, valid values are : -cells -nets -pins -ports -sites"
+  if { $object ne "cells" && $object ne "nets" && $object ne "pins" && $object ne "ports" && $object ne "sites" } {
+    puts "Error: Illegal value for argument object, valid values are : cells nets pins ports sites"
     return $ret_values
   }
-  if { $object eq "-cells" } {
+  if { $object eq "cells" } {
     set ret_values [get_cells -filter { IS_REUSED ==0 && IS_PRIMITIVE==1 && REF_NAME!=GND && REF_NAME!=VCC} -hierarchical ]
   }
 
-  if { $object eq "-nets" } {
+  if { $object eq "nets" } {
     set ret_values [get_nets -filter { REUSE_STATUS=="NON_REUSED" && ROUTE_STATUS!=INTRASITE} -hierarchical ]
   }
 
-  if { $object eq "-pins" } {
+  if { $object eq "pins" } {
     set ret_values [get_pins -filter { is_reused==0 } -hierarchical ]
   }
 
-  if { $object eq "-ports" } {
+  if { $object eq "ports" } {
     set ret_values [get_ports -filter { is_reused==0 }]
   }
-  if { $object eq "-sites" } {
+  if { $object eq "sites" } {
     set non_reused_sites "";
     foreach site [get_sites -filter {IS_USED==1} ] {
       set reused [llength [get_cells -of_objects [get_sites $site] -filter {is_reused==1}]];

--- a/tclapp/xilinx/incrcompile/get_reused.tcl
+++ b/tclapp/xilinx/incrcompile/get_reused.tcl
@@ -8,8 +8,8 @@ proc ::tclapp::xilinx::incrcompile::get_reused { object {reuse_category ""}} {
   # Summary : get reused objects
 
   # Argument Usage:
-  #  object : The object type. The valid values are : -cells -nets -pins -ports -sites
-  #  reuse_category : The valid values are : -fully -partially. This argument is allowed only with object type of -nets or -sites
+  #  object : The object type. The valid values are : cells nets pins ports sites
+  #  reuse_category : The valid values are : fully partially. This argument is allowed only with object type of nets or sites
 
   # Return Value:
   # list of reused objects
@@ -17,40 +17,40 @@ proc ::tclapp::xilinx::incrcompile::get_reused { object {reuse_category ""}} {
   # Categories: xilinxtclstore, incrcompile
 
   set ret_values {}
-  if { $object ne "-cells" && $object ne "-nets" && $object ne "-pins" && $object ne "-ports" && $object ne "-sites" } {
-    puts "Error: Illegal value for argument object, valid values are : -cells -nets -pins -ports -sites"
+  if { $object ne "cells" && $object ne "nets" && $object ne "pins" && $object ne "ports" && $object ne "sites" } {
+    puts "Error: Illegal value for argument object, valid values are : cells nets pins ports sites"
     return $ret_values
   }
-  if { $reuse_category ne "" && ($object ne "-nets" && $object ne "-sites") } {
-    puts "Error: Illegal use of argument reuse_category, reuse_category is allowed only with either -sites or -nets"
+  if { $reuse_category ne "" && ($object ne "nets" && $object ne "sites") } {
+    puts "Error: Illegal use of argument reuse_category, reuse_category is allowed only with either sites or nets"
     return $ret_values
   }
-  if { $reuse_category ne "" && $reuse_category ne "-fully" && $reuse_category ne "-partially"} {
-    puts "Error: Illegal value for argument reuse_category, valid values are : -fully -partially"
+  if { $reuse_category ne "" && $reuse_category ne "fully" && $reuse_category ne "partially"} {
+    puts "Error: Illegal value for argument reuse_category, valid values are : fully partially"
     return $ret_values
   }
-  if { $object eq "-cells" } {
+  if { $object eq "cells" } {
     set ret_values [get_cells -filter { REUSE_STATUS=="Reused" } -hierarchical ]
   }
 
-  if { $object eq "-nets" } {
+  if { $object eq "nets" } {
     if { $reuse_category eq "" } {
       set ret_values [get_nets -filter { REUSE_STATUS=="Reused" || REUSE_STATUS=="PARTIALLY_REUSED" } -hierarchical ]
-    } elseif { $reuse_category eq "-fully" } {
+    } elseif { $reuse_category eq "fully" } {
       set ret_values [get_nets -filter { REUSE_STATUS=="Reused" } -hierarchical ]
     } else {
       set ret_values [get_nets -filter { REUSE_STATUS=="PARTIALLY_REUSED" } -hierarchical ]
     }
   }
 
-  if { $object eq "-pins" } {
+  if { $object eq "pins" } {
     set ret_values [get_pins -filter { is_reused==1 } -hierarchical ]
   }
 
-  if { $object eq "-ports" } {
+  if { $object eq "ports" } {
     set ret_values [get_ports -filter { is_reused==1 }]
   }
-  if { $object eq "-sites" } {
+  if { $object eq "sites" } {
     set fully_reused_sites "";
     set partially_reused_sites "";
     set non_reused_sites "";
@@ -69,7 +69,7 @@ proc ::tclapp::xilinx::incrcompile::get_reused { object {reuse_category ""}} {
     }
     if { $reuse_category eq "" } {
       set ret_values $reused_sites
-    } elseif { $reuse_category eq "-fully" } {
+    } elseif { $reuse_category eq "fully" } {
       set ret_values $fully_reused_sites
     } else {
       set ret_values $partially_reused_sites

--- a/tclapp/xilinx/incrcompile/highlight_non_reused.tcl
+++ b/tclapp/xilinx/incrcompile/highlight_non_reused.tcl
@@ -8,16 +8,16 @@ proc ::tclapp::xilinx::incrcompile::highlight_non_reused { object } {
   # Summary : highlight non reused objects
 
   # Argument Usage:
-  #  object : The object type. The valid values are : -cells -nets -pins -ports -sites
+  #  object : The object type. The valid values are : cells nets pins ports sites
 
   # Return Value:
   # none, objects are highlighted with different colors on GUI
 
   # Categories: xilinxtclstore, incrcompile
 
-  if { $object ne "-cells" && $object ne "-nets" && $object ne "-pins" && $object ne "-ports" && $object ne "-sites" } {
-    puts "Error: Illegal value for argument object, valid values are : -cells -nets -pins -ports -sites"
+  if { $object ne "cells" && $object ne "nets" && $object ne "pins" && $object ne "ports" && $object ne "sites" } {
+    puts "Error: Illegal value for argument object, valid values are : cells nets pins ports sites"
     return
   }
-  highlight_objects -color red [get_non_reused $object]
+  highlight_objects -color red [::tclapp::xilinx::incrcompile::get_non_reused $object]
 }

--- a/tclapp/xilinx/incrcompile/highlight_reused.tcl
+++ b/tclapp/xilinx/incrcompile/highlight_reused.tcl
@@ -8,25 +8,25 @@ proc ::tclapp::xilinx::incrcompile::highlight_reused { object {reuse_category ""
   # Summary : highlight reused objects
 
   # Argument Usage:
-  #  object : The object type. The valid values are : -cells -nets -pins -ports -sites
-  #  reuse_category : The valid values are : -fully -partially. This argument is allowed only with object type of -nets or -sites
+  #  object : The object type. The valid values are : cells nets pins ports sites
+  #  reuse_category : The valid values are : fully partially. This argument is allowed only with object type of nets or sites
 
   # Return Value:
   # none, objects are highlighted with different colors on GUI
 
   # Categories: xilinxtclstore, incrcompile
 
-  if { $object ne "-cells" && $object ne "-nets" && $object ne "-pins" && $object ne "-ports" && $object ne "-sites" } {
-    puts "Error: Illegal value for argument object, valid values are : -cells -nets -pins -ports -sites"
+  if { $object ne "cells" && $object ne "nets" && $object ne "pins" && $object ne "ports" && $object ne "sites" } {
+    puts "Error: Illegal value for argument object, valid values are : cells nets pins ports sites"
     return
   }
-  if { $reuse_category ne "" && ($object ne "-nets" && $object ne "-sites") } {
-    puts "Error: Illegal use of argument reuse_category, reuse_category is allowed only with either -sites or -nets"
+  if { $reuse_category ne "" && ($object ne "nets" && $object ne "sites") } {
+    puts "Error: Illegal use of argument reuse_category, reuse_category is allowed only with either sites or nets"
     return
   }
-  if { $reuse_category ne "" && $reuse_category ne "-fully" && $reuse_category ne "-partially"} {
-    puts "Error: Illegal value for argument reuse_category, valid values are : -fully -partially"
+  if { $reuse_category ne "" && $reuse_category ne "fully" && $reuse_category ne "partially"} {
+    puts "Error: Illegal value for argument reuse_category, valid values are : fully partially"
     return
   }
-  highlight_objects -color green [get_reused $object $reuse_category]
+  highlight_objects -color green [::tclapp::xilinx::incrcompile::get_reused $object $reuse_category]
 }


### PR DESCRIPTION
The reason for renaming is because, the tcl infra of Vivado is not allowing proc arguments to have "-" symbol, it is treating it as a switch as erroring out as below

xilinx::incrcompile::get_reused -cells
ERROR: [Common 17-170] Unknown option '-cells', please type 'xilinx::incrcompile::get_reused -help' for usage info.
