### PR TITLE
Added a user ip_repo refresh when importing a project

### DIFF
--- a/tclapp/xilinx/projutils/write_project_tcl.tcl
+++ b/tclapp/xilinx/projutils/write_project_tcl.tcl
@@ -446,6 +446,9 @@ proc write_specified_fileset { proj_dir proj_name filesets } {
           set repo_path_str [join $path_list " "]
           lappend l_script_data "set_property \"ip_repo_paths\" \"${repo_path_str}\" \$obj" 
           lappend l_script_data "" 
+          lappend l_script_data "# Rebuild user ip_repo's index before adding any source files"
+          lappend l_script_data "update_ip_catalog -rebuild"
+          lappend l_script_data ""
         }
       }
     }


### PR DESCRIPTION
A bug was present when running synthesis immediately after sourcing the generated script.
Test design details:
- Manual created top file (verilog)
- Custom ip_core from user ip_repo instantiated.
- No block design files

Errors obtained:
- [Synth 8-285] failed synthesizing module...
- [Common 17-69] Command failed: Synthesis failed - please see the console or run log file for details
