### PR TITLE
- set ModelSim/Questa incremental and IES update to 1

### DIFF
--- a/tclapp/xilinx/ies/app.xml
+++ b/tclapp/xilinx/ies/app.xml
@@ -2,7 +2,7 @@
 <catalog>
   <apps>
     <app>
-      <revision_history>refactored code to fix top-library fetching flow for manual mode</revision_history>
+      <revision_history>refactored unifast property</revision_history>
       <name>ies</name>
       <pkg_require>Vivado 2014.1</pkg_require>
       <company>xilinx</company>

--- a/tclapp/xilinx/ies/ies.tcl
+++ b/tclapp/xilinx/ies/ies.tcl
@@ -9,4 +9,4 @@ namespace eval ::tclapp::xilinx::ies {
     lappend ::auto_path $home
   }
 }
-package provide ::tclapp::xilinx::ies 2.16
+package provide ::tclapp::xilinx::ies 2.17

--- a/tclapp/xilinx/ies/pkgIndex.tcl
+++ b/tclapp/xilinx/ies/pkgIndex.tcl
@@ -8,4 +8,4 @@
 # script is sourced, the variable $dir must contain the
 # full path name of this file's directory.
 
-package ifneeded ::tclapp::xilinx::ies 2.16 [list source [file join $dir ies.tcl]]
+package ifneeded ::tclapp::xilinx::ies 2.17 [list source [file join $dir ies.tcl]]

--- a/tclapp/xilinx/ies/register_options.tcl
+++ b/tclapp/xilinx/ies/register_options.tcl
@@ -36,11 +36,10 @@ proc register_options { simulator } {
     {{compile.v93}                   {bool}   {1}        {Enable VHDL93 features}}
     {{compile.relax}                 {bool}   {1}        {Enable relaxed VHDL interpretation}}
     {{compile.load_glbl}             {bool}   {1}        {Load GLBL module}}
-    {{compile.update}                {bool}   {0}        {Check if unit is up-to-date before writing}}
+    {{compile.update}                {bool}   {1}        {Check if unit is up-to-date before writing}}
     {{compile.ncvhdl.more_options}   {string} {}         {More NCVHDL compilation options}}
     {{compile.ncvlog.more_options}   {string} {}         {More NCVLOG compilation options}}
     {{elaborate.update}              {bool}   {0}        {Check if unit is up-to-date before writing}}
-    {{elaborate.unifast}             {bool}   {0}        {Enable fast simulation models}}
     {{elaborate.ncelab.more_options} {string} {}         {More NCELAB elaboration options}}
     {{simulate.runtime}              {string} {1000ns}   {Specify simulation run time}}
     {{simulate.uut}                  {string} {}         {Specify instance name for design under test (default:/uut)}}

--- a/tclapp/xilinx/ies/sim.tcl
+++ b/tclapp/xilinx/ies/sim.tcl
@@ -580,14 +580,19 @@ proc usf_ies_write_elaborate_script {} {
   }
 
   # behavioral simulation
-  set b_compile_unifast [get_property "IES.ELABORATE.UNIFAST" $fs_obj]
+  set b_compile_unifast 0
+  set simulator_language [string tolower [get_property simulator_language [current_project]]]
+  if { ([get_param "simulation.addUnifastLibraryForVhdl"]) && ({vhdl} == $simulator_language) } {
+    set b_compile_unifast [get_property "unifast" $fs_obj]
+  }
 
   if { ([::tclapp::xilinx::ies::usf_contains_vhdl $::tclapp::xilinx::ies::a_sim_vars(l_design_files)]) && ({behav_sim} == $sim_flow) } {
-    if { $b_compile_unifast && [get_param "simulation.addUnifastLibraryForVhdl"] } {
+    if { $b_compile_unifast } {
       set arg_list [linsert $arg_list end "-libname" "unifast"]
     }
   }
 
+  set b_compile_unifast [get_property "unifast" $fs_obj]
   if { ([usf_contains_verilog $::tclapp::xilinx::ies::a_sim_vars(l_design_files)]) && ({behav_sim} == $sim_flow) } {
     if { $b_compile_unifast } {
       set arg_list [linsert $arg_list end "-libname" "unifast_ver"]

--- a/tclapp/xilinx/modelsim/app.xml
+++ b/tclapp/xilinx/modelsim/app.xml
@@ -2,7 +2,7 @@
 <catalog>
   <apps>
     <app>
-      <revision_history>refactored code to fix top-library fetching flow for manual mode</revision_history>
+      <revision_history>refactored unifast property</revision_history>
       <name>modelsim</name>
       <pkg_require>Vivado 2014.1</pkg_require>
       <company>xilinx</company>

--- a/tclapp/xilinx/modelsim/helpers.tcl
+++ b/tclapp/xilinx/modelsim/helpers.tcl
@@ -2112,7 +2112,10 @@ proc usf_append_compiler_options { tool file_type opts_arg } {
     }
     "vlog" {
       if { [get_param "project.writeNativeScriptForUnifiedSimulation"] } {
-        set arg_list [list $s_64bit "-incr"]
+        set arg_list [list $s_64bit]
+        if { [get_property "MODELSIM.COMPILE.INCREMENTAL" $fs_obj] } {
+          lappend arg_list "-incr"
+        }
         set more_options [string trim [get_property "MODELSIM.COMPILE.VLOG.MORE_OPTIONS" $fs_obj]]
         if { {} != $more_options } {
           set arg_list [linsert $arg_list end "$more_options"]

--- a/tclapp/xilinx/modelsim/modelsim.tcl
+++ b/tclapp/xilinx/modelsim/modelsim.tcl
@@ -9,4 +9,4 @@ namespace eval ::tclapp::xilinx::modelsim {
     lappend ::auto_path $home
   }
 }
-package provide ::tclapp::xilinx::modelsim 2.22
+package provide ::tclapp::xilinx::modelsim 2.23

--- a/tclapp/xilinx/modelsim/pkgIndex.tcl
+++ b/tclapp/xilinx/modelsim/pkgIndex.tcl
@@ -8,4 +8,4 @@
 # script is sourced, the variable $dir must contain the
 # full path name of this file's directory.
 
-package ifneeded ::tclapp::xilinx::modelsim 2.22 [list source [file join $dir modelsim.tcl]]
+package ifneeded ::tclapp::xilinx::modelsim 2.23 [list source [file join $dir modelsim.tcl]]

--- a/tclapp/xilinx/modelsim/register_options.tcl
+++ b/tclapp/xilinx/modelsim/register_options.tcl
@@ -37,11 +37,10 @@ proc register_options { simulator } {
     {{compile.vhdl_syntax}         {enum}   {{93} {93} {{93} {87} {2002} {2008}}}   {Specify VHDL syntax}}
     {{compile.use_explicit_decl}   {bool}   {1}                                     {Log all signals}}
     {{compile.load_glbl}           {bool}   {1}                                     {Load GLBL module}}
-    {{compile.incremental}         {bool}   {0}                                     {Perform incremental compilation}}
+    {{compile.incremental}         {bool}   {1}                                     {Perform incremental compilation}}
     {{compile.vlog.more_options}   {string} {}                                      {More VLOG compilation options}}
     {{compile.vcom.more_options}   {string} {}                                      {More VCOM compilation options}}
     {{elaborate.acc}               {bool}   {1}                                     {Enable access to certain objects which might otherwise be optimized away}}
-    {{elaborate.unifast}           {bool}   {0}                                     {Enable fast simulation models}}
     {{elaborate.vopt.more_options} {string} {}                                      {More VOPT elaboration options}}
     {{simulate.runtime}            {string} {1000ns}                                {Specify simulation run time}}
     {{simulate.log_all_signals}    {bool}   {0}                                     {Log all signals}}

--- a/tclapp/xilinx/projutils/app.xml
+++ b/tclapp/xilinx/projutils/app.xml
@@ -2,7 +2,7 @@
 <catalog>
   <apps>
     <app>
-      <revision_history>Removed extra quotes from file variable, it interferes with file normalize</revision_history>
+      <revision_history>fixed ip file name extention for .bd</revision_history>
       <name>projutils</name>
       <pkg_require>Vivado 2014.1</pkg_require>
       <company>xilinx</company>

--- a/tclapp/xilinx/projutils/pkgIndex.tcl
+++ b/tclapp/xilinx/projutils/pkgIndex.tcl
@@ -8,4 +8,4 @@
 # script is sourced, the variable $dir must contain the
 # full path name of this file's directory.
 
-package ifneeded ::tclapp::xilinx::projutils 3.18 [list source [file join $dir projutils.tcl]]
+package ifneeded ::tclapp::xilinx::projutils 3.19 [list source [file join $dir projutils.tcl]]

--- a/tclapp/xilinx/projutils/projutils.tcl
+++ b/tclapp/xilinx/projutils/projutils.tcl
@@ -9,4 +9,4 @@ namespace eval ::tclapp::xilinx::projutils {
     lappend ::auto_path $home
   }
 }
-package provide ::tclapp::xilinx::projutils 3.18
+package provide ::tclapp::xilinx::projutils 3.19

--- a/tclapp/xilinx/questa/app.xml
+++ b/tclapp/xilinx/questa/app.xml
@@ -2,7 +2,7 @@
 <catalog>
   <apps>
     <app>
-      <revision_history>refactored code to fix top-library fetching flow for manual mode</revision_history>
+      <revision_history>refactored unifast property</revision_history>
       <name>questa</name>
       <pkg_require>Vivado 2014.1</pkg_require>
       <company>xilinx</company>

--- a/tclapp/xilinx/questa/helpers.tcl
+++ b/tclapp/xilinx/questa/helpers.tcl
@@ -2107,7 +2107,10 @@ proc usf_append_compiler_options { tool file_type opts_arg } {
     }
     "vlog" {
       if { [get_param "project.writeNativeScriptForUnifiedSimulation"] } {
-        set arg_list [list $s_64bit "-incr"]
+        set arg_list [list $s_64bit]
+        if { [get_property "QUESTA.COMPILE.INCREMENTAL" $fs_obj] } {
+          lappend arg_list "-incr"
+        }
         set more_options [string trim [get_property "QUESTA.COMPILE.VLOG.MORE_OPTIONS" $fs_obj]]
         if { {} != $more_options } {
           set arg_list [linsert $arg_list end "$more_options"]

--- a/tclapp/xilinx/questa/pkgIndex.tcl
+++ b/tclapp/xilinx/questa/pkgIndex.tcl
@@ -8,4 +8,4 @@
 # script is sourced, the variable $dir must contain the
 # full path name of this file's directory.
 
-package ifneeded ::tclapp::xilinx::questa 1.13 [list source [file join $dir questa.tcl]]
+package ifneeded ::tclapp::xilinx::questa 1.14 [list source [file join $dir questa.tcl]]

--- a/tclapp/xilinx/questa/questa.tcl
+++ b/tclapp/xilinx/questa/questa.tcl
@@ -9,4 +9,4 @@ namespace eval ::tclapp::xilinx::questa {
     lappend ::auto_path $home
   }
 }
-package provide ::tclapp::xilinx::questa 1.13
+package provide ::tclapp::xilinx::questa 1.14

--- a/tclapp/xilinx/questa/register_options.tcl
+++ b/tclapp/xilinx/questa/register_options.tcl
@@ -37,11 +37,10 @@ proc register_options { simulator } {
     {{compile.vhdl_syntax}         {enum}   {{93} {93} {{93} {87} {2002} {2008}}}   {Specify VHDL syntax}}
     {{compile.use_explicit_decl}   {bool}   {1}                                     {Log all signals}}
     {{compile.load_glbl}           {bool}   {1}                                     {Load GLBL module}}
-    {{compile.incremental}         {bool}   {0}                                     {Perform incremental compilation}}
+    {{compile.incremental}         {bool}   {1}                                     {Perform incremental compilation}}
     {{compile.vlog.more_options}   {string} {}                                      {More VLOG compilation options}}
     {{compile.vcom.more_options}   {string} {}                                      {More VCOM compilation options}}
     {{elaborate.acc}               {bool}   {1}                                     {Enable access to certain objects which might otherwise be optimized away}}
-    {{elaborate.unifast}           {bool}   {0}                                     {Enable fast simulation models}}
     {{elaborate.vopt.more_options} {string} {}                                      {More VOPT elaboration options}}
     {{simulate.runtime}            {string} {1000ns}                                {Specify simulation run time}}
     {{simulate.log_all_signals}    {bool}   {0}                                     {Log all signals}}

--- a/tclapp/xilinx/questa/sim.tcl
+++ b/tclapp/xilinx/questa/sim.tcl
@@ -513,7 +513,10 @@ proc usf_questa_create_do_file_for_compilation { do_file } {
     }
   }
 
-  set vlog_arg_list [list "-incr"]
+  set vlog_arg_list [list]
+  if { [get_property "QUESTA.COMPILE.INCREMENTAL" $fs_obj] } {
+    lappend vlog_arg_list "-incr"
+  }
   set more_vlog_options [string trim [get_property "QUESTA.COMPILE.VLOG.MORE_OPTIONS" $fs_obj]]
   if { {} != $more_vlog_options } {
     set vlog_arg_list [linsert $vlog_arg_list end "$more_vlog_options"]
@@ -726,14 +729,19 @@ proc usf_questa_get_elaboration_cmdline {} {
   }
 
   # behavioral simulation
-  set b_compile_unifast [get_property "QUESTA.ELABORATE.UNIFAST" $fs_obj]
+  set b_compile_unifast 0
+  set simulator_language [string tolower [get_property simulator_language [current_project]]]
+  if { ([get_param "simulation.addUnifastLibraryForVhdl"]) && ({vhdl} == $simulator_language) } {
+    set b_compile_unifast [get_property "unifast" $fs_obj]
+  }
 
   if { ([::tclapp::xilinx::questa::usf_contains_vhdl $design_files]) && ({behav_sim} == $sim_flow) } {
-    if { $b_compile_unifast && [get_param "simulation.addUnifastLibraryForVhdl"] } {
+    if { $b_compile_unifast } {
       set arg_list [linsert $arg_list end "-L" "unifast"]
     }
   }
 
+  set b_compile_unifast [get_property "unifast" $fs_obj]
   if { ([usf_contains_verilog $design_files]) && ({behav_sim} == $sim_flow) } {
     if { $b_compile_unifast } {
       set arg_list [linsert $arg_list end "-L" "unifast_ver"]
@@ -1058,14 +1066,38 @@ proc usf_add_quit_on_error { fh step } {
   # Summary:
   # Argument Usage:
   # Return Value:
-  set b_batch $::tclapp::xilinx::questa::a_sim_vars(b_batch)
-  if { ({compile} == $step) || ({elaborate} == $step) || ({simulate} == $step) } {
-    if { $b_batch } {
-      # param default is true (do not exit flow-step on error)
+
+  set b_batch        $::tclapp::xilinx::questa::a_sim_vars(b_batch)
+  set b_scripts_only $::tclapp::xilinx::questa::a_sim_vars(b_scripts_only)
+
+  if { $b_batch } {
+    # native mode (default)
+    if { [get_param "project.writeNativeScriptForUnifiedSimulation"] } {
+      if { {simulate} == $step } {
+        if { [get_param "simulator.modelsimNoQuitOnError"] } {
+          # no op
+        } else {
+          puts $fh "onbreak {quit -f}"
+          puts $fh "onerror {quit -f}\n"
+        }
+      }
+    # classic mode
+    } else {
+      if { ({compile} == $step) || ({elaborate} == $step) || ({simulate} == $step) } {
+        if { [get_param "simulator.modelsimNoQuitOnError"] } {
+          # no op
+        } else {
+          puts $fh "onbreak {quit -f}"
+          puts $fh "onerror {quit -f}\n"
+        }
+      }
+    }
+  } elseif { $b_scripts_only } {
+    # for both native and classic modes
+    if { {simulate} == $step } {
       if { [get_param "simulator.modelsimNoQuitOnError"] } {
         # no op
       } else {
-        # exit flow-step on error
         puts $fh "onbreak {quit -f}"
         puts $fh "onerror {quit -f}\n"
       }

--- a/tclapp/xilinx/vcs/app.xml
+++ b/tclapp/xilinx/vcs/app.xml
@@ -2,7 +2,7 @@
 <catalog>
   <apps>
     <app>
-      <revision_history>refactored code to fix top-library fetching flow for manual mode</revision_history>
+      <revision_history>refactored unifast property</revision_history>
       <name>vcs</name>
       <pkg_require>Vivado 2014.1</pkg_require>
       <company>xilinx</company>

--- a/tclapp/xilinx/vcs/pkgIndex.tcl
+++ b/tclapp/xilinx/vcs/pkgIndex.tcl
@@ -8,4 +8,4 @@
 # script is sourced, the variable $dir must contain the
 # full path name of this file's directory.
 
-package ifneeded ::tclapp::xilinx::vcs 2.16 [list source [file join $dir vcs.tcl]]
+package ifneeded ::tclapp::xilinx::vcs 2.17 [list source [file join $dir vcs.tcl]]

--- a/tclapp/xilinx/vcs/register_options.tcl
+++ b/tclapp/xilinx/vcs/register_options.tcl
@@ -37,7 +37,6 @@ proc register_options { simulator } {
     {{compile.vhdlan.more_options}  {string} {}        {More VHDLAN compilation options}}
     {{compile.vlogan.more_options}  {string} {}        {More VLOGAN compilation options}}
     {{elaborate.debug_pp}           {bool}   {1}       {Enable post-process debug access}}
-    {{elaborate.unifast}            {bool}   {0}       {Enable fast simulation models}}
     {{elaborate.vcs.more_options}   {string} {}        {More VCS elaboration options}}
     {{simulate.runtime}             {string} {1000ns}  {Specify simulation run time}}
     {{simulate.uut}                 {string} {}        {Specify instance name for design under test (default:/uut)}}

--- a/tclapp/xilinx/vcs/sim.tcl
+++ b/tclapp/xilinx/vcs/sim.tcl
@@ -271,12 +271,19 @@ proc usf_vcs_write_setup_files {} {
   set libs [list]
 
   # unifast
-  set b_compile_unifast [get_property "VCS.ELABORATE.UNIFAST" $fs_obj]
+  set b_compile_unifast 0
+  set simulator_language [string tolower [get_property simulator_language [current_project]]]
+  if { ([get_param "simulation.addUnifastLibraryForVhdl"]) && ({vhdl} == $simulator_language) } {
+    set b_compile_unifast [get_property "unifast" $fs_obj]
+  }
+
   if { ([::tclapp::xilinx::vcs::usf_contains_vhdl $::tclapp::xilinx::vcs::a_sim_vars(l_design_files)]) && ({behav_sim} == $sim_flow) } {
-    if { $b_compile_unifast && [get_param "simulation.addUnifastLibraryForVhdl"] } {
+    if { $b_compile_unifast } {
       puts $fh "unifast : $lib_map_path/unifast"
     }
   }
+
+  set b_compile_unifast [get_property "unifast" $fs_obj]
   if { ([::tclapp::xilinx::vcs::usf_contains_verilog $::tclapp::xilinx::vcs::a_sim_vars(l_design_files)]) && ({behav_sim} == $sim_flow) } {
     if { $b_compile_unifast } {
       puts $fh "unifast_ver : $lib_map_path/unifast_ver"

--- a/tclapp/xilinx/vcs/vcs.tcl
+++ b/tclapp/xilinx/vcs/vcs.tcl
@@ -9,4 +9,4 @@ namespace eval ::tclapp::xilinx::vcs {
     lappend ::auto_path $home
   }
 }
-package provide ::tclapp::xilinx::vcs 2.16
+package provide ::tclapp::xilinx::vcs 2.17

--- a/tclapp/xilinx/xsim/app.xml
+++ b/tclapp/xilinx/xsim/app.xml
@@ -2,7 +2,7 @@
 <catalog>
   <apps>
     <app>
-      <revision_history>fetch unique wcfg files from xsim.view to avoid xsim error</revision_history>
+      <revision_history>refactored unifast property</revision_history>
       <name>xsim</name>
       <pkg_require>Vivado 2014.1</pkg_require>
       <company>xilinx</company>

--- a/tclapp/xilinx/xsim/pkgIndex.tcl
+++ b/tclapp/xilinx/xsim/pkgIndex.tcl
@@ -8,4 +8,4 @@
 # script is sourced, the variable $dir must contain the
 # full path name of this file's directory.
 
-package ifneeded ::tclapp::xilinx::xsim 2.20 [list source [file join $dir xsim.tcl]]
+package ifneeded ::tclapp::xilinx::xsim 2.21 [list source [file join $dir xsim.tcl]]

--- a/tclapp/xilinx/xsim/register_options.tcl
+++ b/tclapp/xilinx/xsim/register_options.tcl
@@ -45,7 +45,6 @@ proc register_options { simulator } {
     {{elaborate.load_glbl}           {bool}        {1}                                                  {Load GLBL module}}
     {{elaborate.rangecheck}          {bool}        {0}                                                  {Enable runtime value range check for VHDL}}
     {{elaborate.sdf_delay}           {enum}        {{sdfmax} {sdfmax} {{sdfmin} {sdfmax}}}              {Specify SDF timing delay type to be read for use in timing simulation}}
-    {{elaborate.unifast}             {bool}        {0}                                                  {Enable fast simulation models}}
     {{elaborate.xelab.more_options}  {string}      {}                                                   {More XELAB elaboration options}}
     {{simulate.runtime}              {string}      {1000ns}                                             {Specify simulation run time}}
     {{simulate.uut}                  {string}      {}                                                   {Specify instance name for design under test (default:/uut)}}

--- a/tclapp/xilinx/xsim/xsim.tcl
+++ b/tclapp/xilinx/xsim/xsim.tcl
@@ -9,4 +9,4 @@ namespace eval ::tclapp::xilinx::xsim {
     lappend ::auto_path $home
   }
 }
-package provide ::tclapp::xilinx::xsim 2.20
+package provide ::tclapp::xilinx::xsim 2.21


### PR DESCRIPTION
- removed unifast property settings and fixed the unifast library detection code
- fixed filename for .bd types
- fixed the logic for -scripts_only for ModelSim/Questa
- fixed the logic for xelab mt_level property

2015.1 CR fixes (849754, 834836, 834746, 824860, 850634): Please merge all sim apps and projutils for 2015.1, thanks (priority-high)