### PR TITLE
changed get_top_library algorithms to use top_lib in manual compile order mode

### DIFF
--- a/tclapp/xilinx/ies/app.xml
+++ b/tclapp/xilinx/ies/app.xml
@@ -2,7 +2,7 @@
 <catalog>
   <apps>
     <app>
-      <revision_history>removed prefixed dot slash from the relative for fix drive letter path on windows</revision_history>
+      <revision_history>changed get_top_library algorithms to use top_lib in manual compile order mode</revision_history>
       <name>ies</name>
       <pkg_require>Vivado 2014.1</pkg_require>
       <company>xilinx</company>

--- a/tclapp/xilinx/ies/helpers.tcl
+++ b/tclapp/xilinx/ies/helpers.tcl
@@ -623,6 +623,9 @@ proc usf_get_top_library { } {
   set flow    $a_sim_vars(s_simulation_flow)
   set tcl_obj $a_sim_vars(sp_tcl_obj)
 
+  set src_mgmt_mode         [get_property "SOURCE_MGMT_MODE" [current_project]]
+  set manual_compile_order  [expr $src_mgmt_mode != "All"]
+
   # was -of_objects <ip> specified?, fetch current fileset
   if { [usf_is_ip $tcl_obj] } {
     set tcl_obj [get_filesets $a_sim_vars(s_simset)]
@@ -654,6 +657,10 @@ proc usf_get_top_library { } {
   # 4. if default top library is set and the compile order file library is different
   #    than this default, return the compile order file library
   if { {} != $default_top_library } {
+    # manual compile order, we just return the file set's top
+    if { manual_compile_order && ({} != $fs_top_library) } {
+      return $fs_top_library
+    }
     # compile order library is set and is different then the default
     if { ({} != $co_top_library) && ($default_top_library != $co_top_library) } {
       return $co_top_library
@@ -667,6 +674,10 @@ proc usf_get_top_library { } {
   #    if fileset top library is set and the compile order file library is different
   #    than this default, return the compile order file library
   if { {} != $fs_top_library } {
+    # manual compile order, we just return the file set's top
+    if { manual_compile_order } {
+      return $fs_top_library
+    }
     # compile order library is set and is different then the fileset
     if { ({} != $co_top_library) && ($fs_top_library != $co_top_library) } {
       return $co_top_library

--- a/tclapp/xilinx/ies/helpers.tcl
+++ b/tclapp/xilinx/ies/helpers.tcl
@@ -624,7 +624,7 @@ proc usf_get_top_library { } {
   set tcl_obj $a_sim_vars(sp_tcl_obj)
 
   set src_mgmt_mode         [get_property "SOURCE_MGMT_MODE" [current_project]]
-  set manual_compile_order  [expr $src_mgmt_mode != "All"]
+  set manual_compile_order  [expr {$src_mgmt_mode != "All"}]
 
   # was -of_objects <ip> specified?, fetch current fileset
   if { [usf_is_ip $tcl_obj] } {

--- a/tclapp/xilinx/ies/helpers.tcl
+++ b/tclapp/xilinx/ies/helpers.tcl
@@ -658,7 +658,7 @@ proc usf_get_top_library { } {
   #    than this default, return the compile order file library
   if { {} != $default_top_library } {
     # manual compile order, we just return the file set's top
-    if { manual_compile_order && ({} != $fs_top_library) } {
+    if { $manual_compile_order && ({} != $fs_top_library) } {
       return $fs_top_library
     }
     # compile order library is set and is different then the default
@@ -675,7 +675,7 @@ proc usf_get_top_library { } {
   #    than this default, return the compile order file library
   if { {} != $fs_top_library } {
     # manual compile order, we just return the file set's top
-    if { manual_compile_order } {
+    if { $manual_compile_order } {
       return $fs_top_library
     }
     # compile order library is set and is different then the fileset

--- a/tclapp/xilinx/ies/ies.tcl
+++ b/tclapp/xilinx/ies/ies.tcl
@@ -9,4 +9,4 @@ namespace eval ::tclapp::xilinx::ies {
     lappend ::auto_path $home
   }
 }
-package provide ::tclapp::xilinx::ies 2.65
+package provide ::tclapp::xilinx::ies 2.66

--- a/tclapp/xilinx/ies/pkgIndex.tcl
+++ b/tclapp/xilinx/ies/pkgIndex.tcl
@@ -8,4 +8,4 @@
 # script is sourced, the variable $dir must contain the
 # full path name of this file's directory.
 
-package ifneeded ::tclapp::xilinx::ies 2.65 [list source [file join $dir ies.tcl]]
+package ifneeded ::tclapp::xilinx::ies 2.66 [list source [file join $dir ies.tcl]]

--- a/tclapp/xilinx/modelsim/app.xml
+++ b/tclapp/xilinx/modelsim/app.xml
@@ -2,7 +2,7 @@
 <catalog>
   <apps>
     <app>
-      <revision_history>wrap include dir file path and incdir in quotes</revision_history>
+      <revision_history>changed get_top_library algorithms to use top_lib in manual compile order mode</revision_history>
       <name>modelsim</name>
       <pkg_require>Vivado 2014.1</pkg_require>
       <company>xilinx</company>

--- a/tclapp/xilinx/modelsim/helpers.tcl
+++ b/tclapp/xilinx/modelsim/helpers.tcl
@@ -551,6 +551,9 @@ proc usf_get_top_library { } {
   set flow    $a_sim_vars(s_simulation_flow)
   set tcl_obj $a_sim_vars(sp_tcl_obj)
 
+  set src_mgmt_mode         [get_property "SOURCE_MGMT_MODE" [current_project]]
+  set manual_compile_order  [expr $src_mgmt_mode != "All"]
+
   # was -of_objects <ip> specified?, fetch current fileset
   if { [usf_is_ip $tcl_obj] } {
     set tcl_obj [get_filesets $a_sim_vars(s_simset)]
@@ -582,6 +585,10 @@ proc usf_get_top_library { } {
   # 4. if default top library is set and the compile order file library is different
   #    than this default, return the compile order file library
   if { {} != $default_top_library } {
+    # manual compile order, we just return the file set's top
+    if { manual_compile_order && ({} != $fs_top_library) } {
+      return $fs_top_library
+    }
     # compile order library is set and is different then the default
     if { ({} != $co_top_library) && ($default_top_library != $co_top_library) } {
       return $co_top_library
@@ -595,6 +602,10 @@ proc usf_get_top_library { } {
   #    if fileset top library is set and the compile order file library is different
   #    than this default, return the compile order file library
   if { {} != $fs_top_library } {
+    # manual compile order, we just return the file set's top
+    if { manual_compile_order } {
+      return $fs_top_library
+    }
     # compile order library is set and is different then the fileset
     if { ({} != $co_top_library) && ($fs_top_library != $co_top_library) } {
       return $co_top_library

--- a/tclapp/xilinx/modelsim/helpers.tcl
+++ b/tclapp/xilinx/modelsim/helpers.tcl
@@ -586,7 +586,7 @@ proc usf_get_top_library { } {
   #    than this default, return the compile order file library
   if { {} != $default_top_library } {
     # manual compile order, we just return the file set's top
-    if { manual_compile_order && ({} != $fs_top_library) } {
+    if { $manual_compile_order && ({} != $fs_top_library) } {
       return $fs_top_library
     }
     # compile order library is set and is different then the default
@@ -603,7 +603,7 @@ proc usf_get_top_library { } {
   #    than this default, return the compile order file library
   if { {} != $fs_top_library } {
     # manual compile order, we just return the file set's top
-    if { manual_compile_order } {
+    if { $manual_compile_order } {
       return $fs_top_library
     }
     # compile order library is set and is different then the fileset

--- a/tclapp/xilinx/modelsim/helpers.tcl
+++ b/tclapp/xilinx/modelsim/helpers.tcl
@@ -552,7 +552,7 @@ proc usf_get_top_library { } {
   set tcl_obj $a_sim_vars(sp_tcl_obj)
 
   set src_mgmt_mode         [get_property "SOURCE_MGMT_MODE" [current_project]]
-  set manual_compile_order  [expr $src_mgmt_mode != "All"]
+  set manual_compile_order  [expr {$src_mgmt_mode != "All"}]
 
   # was -of_objects <ip> specified?, fetch current fileset
   if { [usf_is_ip $tcl_obj] } {

--- a/tclapp/xilinx/modelsim/modelsim.tcl
+++ b/tclapp/xilinx/modelsim/modelsim.tcl
@@ -9,4 +9,4 @@ namespace eval ::tclapp::xilinx::modelsim {
     lappend ::auto_path $home
   }
 }
-package provide ::tclapp::xilinx::modelsim 2.74
+package provide ::tclapp::xilinx::modelsim 2.75

--- a/tclapp/xilinx/modelsim/pkgIndex.tcl
+++ b/tclapp/xilinx/modelsim/pkgIndex.tcl
@@ -8,4 +8,4 @@
 # script is sourced, the variable $dir must contain the
 # full path name of this file's directory.
 
-package ifneeded ::tclapp::xilinx::modelsim 2.74 [list source [file join $dir modelsim.tcl]]
+package ifneeded ::tclapp::xilinx::modelsim 2.75 [list source [file join $dir modelsim.tcl]]

--- a/tclapp/xilinx/projutils/app.xml
+++ b/tclapp/xilinx/projutils/app.xml
@@ -2,7 +2,7 @@
 <catalog>
   <apps>
     <app>
-      <revision_history>removed prefixed dot slash from the relative for fix drive letter path on windows</revision_history>
+      <revision_history>changed get_top_library algorithms to use top_lib in manual compile order mode</revision_history>
       <name>projutils</name>
       <pkg_require>Vivado 2014.1</pkg_require>
       <company>xilinx</company>

--- a/tclapp/xilinx/projutils/export_simulation.tcl
+++ b/tclapp/xilinx/projutils/export_simulation.tcl
@@ -3623,6 +3623,9 @@ proc xps_get_top_library { } {
 
   set tcl_obj $a_sim_vars(sp_tcl_obj)
 
+  set src_mgmt_mode         [get_property "SOURCE_MGMT_MODE" [current_project]]
+  set manual_compile_order  [expr $src_mgmt_mode != "All"]
+
   # was -of_objects <ip> specified?, fetch current fileset
   if { [xps_is_ip $tcl_obj] } {
     set tcl_obj $a_sim_vars(fs_obj)
@@ -3647,6 +3650,10 @@ proc xps_get_top_library { } {
   # 4. if default top library is set and the compile order file library is different
   #    than this default, return the compile order file library
   if { {} != $default_top_library } {
+    # manual compile order, we just return the file set's top
+    if { manual_compile_order && ({} != $fs_top_library) } {
+      return $fs_top_library
+    }
     # compile order library is set and is different then the default
     if { ({} != $co_top_library) && ($default_top_library != $co_top_library) } {
       return $co_top_library
@@ -3660,6 +3667,10 @@ proc xps_get_top_library { } {
   #    if fileset top library is set and the compile order file library is different
   #    than this default, return the compile order file library
   if { {} != $fileset_top_library } {
+    # manual compile order, we just return the file set's top
+    if { manual_compile_order } {
+      return $fs_top_library
+    }
     # compile order library is set and is different then the fileset
     if { ({} != $co_top_library) && ($fileset_top_library != $co_top_library) } {
       return $co_top_library

--- a/tclapp/xilinx/projutils/export_simulation.tcl
+++ b/tclapp/xilinx/projutils/export_simulation.tcl
@@ -3624,7 +3624,7 @@ proc xps_get_top_library { } {
   set tcl_obj $a_sim_vars(sp_tcl_obj)
 
   set src_mgmt_mode         [get_property "SOURCE_MGMT_MODE" [current_project]]
-  set manual_compile_order  [expr $src_mgmt_mode != "All"]
+  set manual_compile_order  [expr {$src_mgmt_mode != "All"}]
 
   # was -of_objects <ip> specified?, fetch current fileset
   if { [xps_is_ip $tcl_obj] } {

--- a/tclapp/xilinx/projutils/export_simulation.tcl
+++ b/tclapp/xilinx/projutils/export_simulation.tcl
@@ -3651,7 +3651,7 @@ proc xps_get_top_library { } {
   #    than this default, return the compile order file library
   if { {} != $default_top_library } {
     # manual compile order, we just return the file set's top
-    if { manual_compile_order && ({} != $fs_top_library) } {
+    if { $manual_compile_order && ({} != $fs_top_library) } {
       return $fs_top_library
     }
     # compile order library is set and is different then the default
@@ -3668,7 +3668,7 @@ proc xps_get_top_library { } {
   #    than this default, return the compile order file library
   if { {} != $fileset_top_library } {
     # manual compile order, we just return the file set's top
-    if { manual_compile_order } {
+    if { $manual_compile_order } {
       return $fs_top_library
     }
     # compile order library is set and is different then the fileset

--- a/tclapp/xilinx/projutils/pkgIndex.tcl
+++ b/tclapp/xilinx/projutils/pkgIndex.tcl
@@ -8,4 +8,4 @@
 # script is sourced, the variable $dir must contain the
 # full path name of this file's directory.
 
-package ifneeded ::tclapp::xilinx::projutils 3.90 [list source [file join $dir projutils.tcl]]
+package ifneeded ::tclapp::xilinx::projutils 3.91 [list source [file join $dir projutils.tcl]]

--- a/tclapp/xilinx/projutils/projutils.tcl
+++ b/tclapp/xilinx/projutils/projutils.tcl
@@ -9,4 +9,4 @@ namespace eval ::tclapp::xilinx::projutils {
     lappend ::auto_path $home
   }
 }
-package provide ::tclapp::xilinx::projutils 3.90
+package provide ::tclapp::xilinx::projutils 3.91

--- a/tclapp/xilinx/questa/app.xml
+++ b/tclapp/xilinx/questa/app.xml
@@ -2,7 +2,7 @@
 <catalog>
   <apps>
     <app>
-      <revision_history>wrap include dir file path and incdir in quotes</revision_history>
+      <revision_history>changed get_top_library algorithms to use top_lib in manual compile order mode</revision_history>
       <name>questa</name>
       <pkg_require>Vivado 2014.1</pkg_require>
       <company>xilinx</company>

--- a/tclapp/xilinx/questa/helpers.tcl
+++ b/tclapp/xilinx/questa/helpers.tcl
@@ -551,6 +551,9 @@ proc usf_get_top_library { } {
   set flow    $a_sim_vars(s_simulation_flow)
   set tcl_obj $a_sim_vars(sp_tcl_obj)
 
+  set src_mgmt_mode         [get_property "SOURCE_MGMT_MODE" [current_project]]
+  set manual_compile_order  [expr $src_mgmt_mode != "All"]
+
   # was -of_objects <ip> specified?, fetch current fileset
   if { [usf_is_ip $tcl_obj] } {
     set tcl_obj [get_filesets $a_sim_vars(s_simset)]
@@ -582,6 +585,10 @@ proc usf_get_top_library { } {
   # 4. if default top library is set and the compile order file library is different
   #    than this default, return the compile order file library
   if { {} != $default_top_library } {
+    # manual compile order, we just return the file set's top
+    if { manual_compile_order && ({} != $fs_top_library) } {
+      return $fs_top_library
+    }
     # compile order library is set and is different then the default
     if { ({} != $co_top_library) && ($default_top_library != $co_top_library) } {
       return $co_top_library
@@ -595,6 +602,10 @@ proc usf_get_top_library { } {
   #    if fileset top library is set and the compile order file library is different
   #    than this default, return the compile order file library
   if { {} != $fs_top_library } {
+    # manual compile order, we just return the file set's top
+    if { manual_compile_order } {
+      return $fs_top_library
+    }
     # compile order library is set and is different then the fileset
     if { ({} != $co_top_library) && ($fs_top_library != $co_top_library) } {
       return $co_top_library

--- a/tclapp/xilinx/questa/helpers.tcl
+++ b/tclapp/xilinx/questa/helpers.tcl
@@ -586,7 +586,7 @@ proc usf_get_top_library { } {
   #    than this default, return the compile order file library
   if { {} != $default_top_library } {
     # manual compile order, we just return the file set's top
-    if { manual_compile_order && ({} != $fs_top_library) } {
+    if { $manual_compile_order && ({} != $fs_top_library) } {
       return $fs_top_library
     }
     # compile order library is set and is different then the default
@@ -603,7 +603,7 @@ proc usf_get_top_library { } {
   #    than this default, return the compile order file library
   if { {} != $fs_top_library } {
     # manual compile order, we just return the file set's top
-    if { manual_compile_order } {
+    if { $manual_compile_order } {
       return $fs_top_library
     }
     # compile order library is set and is different then the fileset

--- a/tclapp/xilinx/questa/helpers.tcl
+++ b/tclapp/xilinx/questa/helpers.tcl
@@ -552,7 +552,7 @@ proc usf_get_top_library { } {
   set tcl_obj $a_sim_vars(sp_tcl_obj)
 
   set src_mgmt_mode         [get_property "SOURCE_MGMT_MODE" [current_project]]
-  set manual_compile_order  [expr $src_mgmt_mode != "All"]
+  set manual_compile_order  [expr {$src_mgmt_mode != "All"}]
 
   # was -of_objects <ip> specified?, fetch current fileset
   if { [usf_is_ip $tcl_obj] } {

--- a/tclapp/xilinx/questa/pkgIndex.tcl
+++ b/tclapp/xilinx/questa/pkgIndex.tcl
@@ -8,4 +8,4 @@
 # script is sourced, the variable $dir must contain the
 # full path name of this file's directory.
 
-package ifneeded ::tclapp::xilinx::questa 1.64 [list source [file join $dir questa.tcl]]
+package ifneeded ::tclapp::xilinx::questa 1.65 [list source [file join $dir questa.tcl]]

--- a/tclapp/xilinx/questa/questa.tcl
+++ b/tclapp/xilinx/questa/questa.tcl
@@ -9,4 +9,4 @@ namespace eval ::tclapp::xilinx::questa {
     lappend ::auto_path $home
   }
 }
-package provide ::tclapp::xilinx::questa 1.64
+package provide ::tclapp::xilinx::questa 1.65

--- a/tclapp/xilinx/vcs/app.xml
+++ b/tclapp/xilinx/vcs/app.xml
@@ -2,7 +2,7 @@
 <catalog>
   <apps>
     <app>
-      <revision_history>do not pass unisims_ver for post simulation when target language is vhdl</revision_history>
+      <revision_history>changed get_top_library algorithms to use top_lib in manual compile order mode</revision_history>
       <name>vcs</name>
       <pkg_require>Vivado 2014.1</pkg_require>
       <company>xilinx</company>

--- a/tclapp/xilinx/vcs/helpers.tcl
+++ b/tclapp/xilinx/vcs/helpers.tcl
@@ -626,6 +626,9 @@ proc usf_get_top_library { } {
   set flow    $a_sim_vars(s_simulation_flow)
   set tcl_obj $a_sim_vars(sp_tcl_obj)
 
+  set src_mgmt_mode         [get_property "SOURCE_MGMT_MODE" [current_project]]
+  set manual_compile_order  [expr $src_mgmt_mode != "All"]
+
   # was -of_objects <ip> specified?, fetch current fileset
   if { [usf_is_ip $tcl_obj] } {
     set tcl_obj [get_filesets $a_sim_vars(s_simset)]
@@ -657,6 +660,10 @@ proc usf_get_top_library { } {
   # 4. if default top library is set and the compile order file library is different
   #    than this default, return the compile order file library
   if { {} != $default_top_library } {
+    # manual compile order, we just return the file set's top
+    if { manual_compile_order && ({} != $fs_top_library) } {
+      return $fs_top_library
+    }
     # compile order library is set and is different then the default
     if { ({} != $co_top_library) && ($default_top_library != $co_top_library) } {
       return $co_top_library
@@ -670,6 +677,10 @@ proc usf_get_top_library { } {
   #    if fileset top library is set and the compile order file library is different
   #    than this default, return the compile order file library
   if { {} != $fs_top_library } {
+    # manual compile order, we just return the file set's top
+    if { manual_compile_order } {
+      return $fs_top_library
+    }
     # compile order library is set and is different then the fileset
     if { ({} != $co_top_library) && ($fs_top_library != $co_top_library) } {
       return $co_top_library

--- a/tclapp/xilinx/vcs/helpers.tcl
+++ b/tclapp/xilinx/vcs/helpers.tcl
@@ -627,7 +627,7 @@ proc usf_get_top_library { } {
   set tcl_obj $a_sim_vars(sp_tcl_obj)
 
   set src_mgmt_mode         [get_property "SOURCE_MGMT_MODE" [current_project]]
-  set manual_compile_order  [expr $src_mgmt_mode != "All"]
+  set manual_compile_order  [expr {$src_mgmt_mode != "All"}]
 
   # was -of_objects <ip> specified?, fetch current fileset
   if { [usf_is_ip $tcl_obj] } {

--- a/tclapp/xilinx/vcs/helpers.tcl
+++ b/tclapp/xilinx/vcs/helpers.tcl
@@ -661,7 +661,7 @@ proc usf_get_top_library { } {
   #    than this default, return the compile order file library
   if { {} != $default_top_library } {
     # manual compile order, we just return the file set's top
-    if { manual_compile_order && ({} != $fs_top_library) } {
+    if { $manual_compile_order && ({} != $fs_top_library) } {
       return $fs_top_library
     }
     # compile order library is set and is different then the default
@@ -678,7 +678,7 @@ proc usf_get_top_library { } {
   #    than this default, return the compile order file library
   if { {} != $fs_top_library } {
     # manual compile order, we just return the file set's top
-    if { manual_compile_order } {
+    if { $manual_compile_order } {
       return $fs_top_library
     }
     # compile order library is set and is different then the fileset

--- a/tclapp/xilinx/vcs/pkgIndex.tcl
+++ b/tclapp/xilinx/vcs/pkgIndex.tcl
@@ -8,4 +8,4 @@
 # script is sourced, the variable $dir must contain the
 # full path name of this file's directory.
 
-package ifneeded ::tclapp::xilinx::vcs 2.67 [list source [file join $dir vcs.tcl]]
+package ifneeded ::tclapp::xilinx::vcs 2.68 [list source [file join $dir vcs.tcl]]

--- a/tclapp/xilinx/vcs/vcs.tcl
+++ b/tclapp/xilinx/vcs/vcs.tcl
@@ -9,4 +9,4 @@ namespace eval ::tclapp::xilinx::vcs {
     lappend ::auto_path $home
   }
 }
-package provide ::tclapp::xilinx::vcs 2.67
+package provide ::tclapp::xilinx::vcs 2.68

--- a/tclapp/xilinx/xsim/app.xml
+++ b/tclapp/xilinx/xsim/app.xml
@@ -2,7 +2,7 @@
 <catalog>
   <apps>
     <app>
-      <revision_history>removed prefixed dot slash from the relative for fix drive letter path on windows</revision_history>
+      <revision_history>changed get_top_library algorithms to use top_lib in manual compile order mode</revision_history>
       <name>xsim</name>
       <pkg_require>Vivado 2014.1</pkg_require>
       <company>xilinx</company>

--- a/tclapp/xilinx/xsim/helpers.tcl
+++ b/tclapp/xilinx/xsim/helpers.tcl
@@ -590,6 +590,9 @@ proc usf_get_top_library { } {
   set flow    $a_sim_vars(s_simulation_flow)
   set tcl_obj $a_sim_vars(sp_tcl_obj)
 
+  set src_mgmt_mode         [get_property "SOURCE_MGMT_MODE" [current_project]]
+  set manual_compile_order  [expr $src_mgmt_mode != "All"]
+
   # was -of_objects <ip> specified?, fetch current fileset
   if { [usf_is_ip $tcl_obj] } {
     set tcl_obj [get_filesets $a_sim_vars(s_simset)]
@@ -621,6 +624,9 @@ proc usf_get_top_library { } {
   # 4. if default top library is set and the compile order file library is different
   #    than this default, return the compile order file library 
   if { {} != $default_top_library } {
+    if { manual_compile_order && ({} != $fs_top_library) } {
+      return $fs_top_library
+    }
     # compile order library is set and is different then the default
     if { ({} != $co_top_library) && ($default_top_library != $co_top_library) } {
       return $co_top_library
@@ -634,6 +640,10 @@ proc usf_get_top_library { } {
   #    if fileset top library is set and the compile order file library is different
   #    than this default, return the compile order file library 
   if { {} != $fs_top_library } {
+    # manual compile order, we just return the file set's top
+    if { manual_compile_order } {
+      return $fs_top_library
+    }
     # compile order library is set and is different then the fileset
     if { ({} != $co_top_library) && ($fs_top_library != $co_top_library) } {
       return $co_top_library

--- a/tclapp/xilinx/xsim/helpers.tcl
+++ b/tclapp/xilinx/xsim/helpers.tcl
@@ -591,7 +591,7 @@ proc usf_get_top_library { } {
   set tcl_obj $a_sim_vars(sp_tcl_obj)
 
   set src_mgmt_mode         [get_property "SOURCE_MGMT_MODE" [current_project]]
-  set manual_compile_order  [expr $src_mgmt_mode != "All"]
+  set manual_compile_order  [expr {$src_mgmt_mode != "All"}]
 
   # was -of_objects <ip> specified?, fetch current fileset
   if { [usf_is_ip $tcl_obj] } {

--- a/tclapp/xilinx/xsim/helpers.tcl
+++ b/tclapp/xilinx/xsim/helpers.tcl
@@ -624,7 +624,7 @@ proc usf_get_top_library { } {
   # 4. if default top library is set and the compile order file library is different
   #    than this default, return the compile order file library 
   if { {} != $default_top_library } {
-    if { manual_compile_order && ({} != $fs_top_library) } {
+    if { $manual_compile_order && ({} != $fs_top_library) } {
       return $fs_top_library
     }
     # compile order library is set and is different then the default
@@ -641,7 +641,7 @@ proc usf_get_top_library { } {
   #    than this default, return the compile order file library 
   if { {} != $fs_top_library } {
     # manual compile order, we just return the file set's top
-    if { manual_compile_order } {
+    if { $manual_compile_order } {
       return $fs_top_library
     }
     # compile order library is set and is different then the fileset

--- a/tclapp/xilinx/xsim/pkgIndex.tcl
+++ b/tclapp/xilinx/xsim/pkgIndex.tcl
@@ -8,4 +8,4 @@
 # script is sourced, the variable $dir must contain the
 # full path name of this file's directory.
 
-package ifneeded ::tclapp::xilinx::xsim 2.70 [list source [file join $dir xsim.tcl]]
+package ifneeded ::tclapp::xilinx::xsim 2.71 [list source [file join $dir xsim.tcl]]

--- a/tclapp/xilinx/xsim/xsim.tcl
+++ b/tclapp/xilinx/xsim/xsim.tcl
@@ -9,4 +9,4 @@ namespace eval ::tclapp::xilinx::xsim {
     lappend ::auto_path $home
   }
 }
-package provide ::tclapp::xilinx::xsim 2.70
+package provide ::tclapp::xilinx::xsim 2.71


### PR DESCRIPTION
Please merge with 2015.4 and 2016.1.

This change can also be made available as an 'update' to 2015.3.

CR: 866839