### PR TITLE
changed fs_top_library to fileset_top_library in projutils

### DIFF
--- a/tclapp/xilinx/projutils/app.xml
+++ b/tclapp/xilinx/projutils/app.xml
@@ -2,7 +2,7 @@
 <catalog>
   <apps>
     <app>
-      <revision_history>wrap incdir with include dir path in quotes for ModelSim and Questa flows</revision_history>
+      <revision_history>changed fs_top_lib to fileset_top_lib in projutils</revision_history>
       <name>projutils</name>
       <pkg_require>Vivado 2014.1</pkg_require>
       <company>xilinx</company>

--- a/tclapp/xilinx/projutils/export_simulation.tcl
+++ b/tclapp/xilinx/projutils/export_simulation.tcl
@@ -3659,8 +3659,8 @@ proc xps_get_top_library { } {
   #    than this default, return the compile order file library
   if { {} != $default_top_library } {
     # manual compile order, we just return the file set's top
-    if { $manual_compile_order && ({} != $fs_top_library) } {
-      return $fs_top_library
+    if { $manual_compile_order && ({} != $fileset_top_library) } {
+      return $fileset_top_library
     }
     # compile order library is set and is different then the default
     if { ({} != $co_top_library) && ($default_top_library != $co_top_library) } {
@@ -3677,7 +3677,7 @@ proc xps_get_top_library { } {
   if { {} != $fileset_top_library } {
     # manual compile order, we just return the file set's top
     if { $manual_compile_order } {
-      return $fs_top_library
+      return $fileset_top_library
     }
     # compile order library is set and is different then the fileset
     if { ({} != $co_top_library) && ($fileset_top_library != $co_top_library) } {

--- a/tclapp/xilinx/projutils/pkgIndex.tcl
+++ b/tclapp/xilinx/projutils/pkgIndex.tcl
@@ -8,4 +8,4 @@
 # script is sourced, the variable $dir must contain the
 # full path name of this file's directory.
 
-package ifneeded ::tclapp::xilinx::projutils 3.93 [list source [file join $dir projutils.tcl]]
+package ifneeded ::tclapp::xilinx::projutils 3.94 [list source [file join $dir projutils.tcl]]

--- a/tclapp/xilinx/projutils/projutils.tcl
+++ b/tclapp/xilinx/projutils/projutils.tcl
@@ -9,4 +9,4 @@ namespace eval ::tclapp::xilinx::projutils {
     lappend ::auto_path $home
   }
 }
-package provide ::tclapp::xilinx::projutils 3.93
+package provide ::tclapp::xilinx::projutils 3.94


### PR DESCRIPTION
Please merge following app into XilinxTclStore master and update 2015.3, 2015.4 and 2016.1 catalogs.

App: projutils

CR: 911761
CR TBF Version: 2015.4