### PR TITLE
tk_tunnel: Close cmd when tclsh exits

### DIFF
--- a/tclapp/xilinx/tk_tunnel/communication.tcl
+++ b/tclapp/xilinx/tk_tunnel/communication.tcl
@@ -185,7 +185,7 @@ proc launch_server {{tclsh "tclsh"} {server_file {}}} {
   puts "Attempting to launch server...\n  Server Launch Script:\n    '${server_file}'\n  Tcl Shell Path:\n    '${tclsh_path}'"
   if { $::tcl_platform(platform) == "windows" } {
     #exec {*}[auto_execok start] {} "cmd /k $tclsh_path $server_file" &
-    return [exec $shellCmdPath /c start cmd /k $tclsh_path $server_file &]
+    return [exec $shellCmdPath /c start cmd /c $tclsh_path $server_file &]
   } else {
     #return [exec $shellCmdPath -iconic -e $tclsh_path $server_file &]
     return [exec $shellCmdPath -e $tclsh_path $server_file &]


### PR DESCRIPTION
It is mildly annoying to have to manually close the command prompt when I am finished with Tk, this way `rexec_wait { exit }` will exit tclsh and close the command prompt.