### PR TITLE
Various enhancements to prettyTable for 2016.2/master (xilinx::designutils)

### DIFF
--- a/tclapp/xilinx/designutils/app.xml
+++ b/tclapp/xilinx/designutils/app.xml
@@ -2,7 +2,7 @@
 <catalog>
   <apps>
     <app>
-      <revision_history>Miscellaneous enhancements (timing_report_to_verilog, convert_muxfx_to_luts, create_combined_mig_io_design)</revision_history>
+      <revision_history>Various enhancements to prettyTable</revision_history>
       <name>designutils</name>
       <pkg_require>Vivado 2014.1</pkg_require>
       <company>xilinx</company>

--- a/tclapp/xilinx/designutils/designutils.tcl
+++ b/tclapp/xilinx/designutils/designutils.tcl
@@ -11,4 +11,4 @@ namespace eval ::tclapp::xilinx::designutils {
 
 }
 
-package provide ::tclapp::xilinx::designutils 1.28
+package provide ::tclapp::xilinx::designutils 1.29

--- a/tclapp/xilinx/designutils/pkgIndex.tcl
+++ b/tclapp/xilinx/designutils/pkgIndex.tcl
@@ -8,4 +8,4 @@
 # script is sourced, the variable $dir must contain the
 # full path name of this file's directory.
 
-package ifneeded ::tclapp::xilinx::designutils 1.28 [list source [file join $dir designutils.tcl]]
+package ifneeded ::tclapp::xilinx::designutils 1.29 [list source [file join $dir designutils.tcl]]

--- a/tclapp/xilinx/designutils/revision_history.txt
+++ b/tclapp/xilinx/designutils/revision_history.txt
@@ -1,3 +1,4 @@
+1.29 Various enhancements to prettyTable
 1.28 Miscellaneous enhancements (timing_report_to_verilog, convert_muxfx_to_luts, create_combined_mig_io_design)
 1.27 Fixed missing header inside CSV file + minor enhancements (prettyTable)
 1.26 Enhancements to prettyTable


### PR DESCRIPTION
Details of changes:

2016.08.23 - Updated default alignment for template 'deviceview'
2016.06.30 - Fixed issue with 'delcolumns', 'delrows' methods
2016.06.24 - Added 'search', 'filter', 'prependcell' methods
           - Fixed issue with 'set_param' method
           - Added support for private methods for templates
           - Added 'plotcells', 'plotnets', 'plotregions' methods for
             template 'deviceview'
2016.06.17 - Added 'appendcell', 'cleartable', 'incrcell' methods
           - Added support for -origin/-offsetx/-offsety (configure)
           - Added support for templates for table creation
           - Updated 'separator' method to accept a list of row numbers
             E.g: create table based on device view
2016.06.13 - Added 'setrow', 'setcolumn' methods
2016.06.09 - Added 'delrows', 'delcolumns' methods
           - Added 'getcell', 'setcell' methods
           - Added 'insertcolumn', 'settable' methods
           - Added 'creatematrix' method
2016.05.23 - Updated 'title' method to set/get the table's title
2016.05.20 - Added 'getrow', 'getcolumns', 'gettable' methods
2016.04.08 - Added 'appendrow' method
2016.03.25 - Added 'numcols' method
           - Added new format for 'export' method (array)
           - Fixed help message for 'numrows' method
2016.03.02 - Added -noheader to 'export' method
           - Addes support for -noheader when exporting CSV