### PR TITLE
- check for empty source file object before extracting

### DIFF
--- a/tclapp/xilinx/ies/app.xml
+++ b/tclapp/xilinx/ies/app.xml
@@ -2,7 +2,7 @@
 <catalog>
   <apps>
     <app>
-      <revision_history>extract xml comp files for finding SV pkg libraries</revision_history>
+      <revision_history>check for empty source file object before extracting</revision_history>
       <name>ies</name>
       <pkg_require>Vivado 2014.1</pkg_require>
       <company>xilinx</company>

--- a/tclapp/xilinx/ies/common/utils.tcl
+++ b/tclapp/xilinx/ies/common/utils.tcl
@@ -2328,7 +2328,9 @@ proc xcs_find_sv_pkg_libs { run_dir } {
     if { ![file exists $ip_filename] } {
       # extract files
       set ip_file_obj [get_files -all -quiet $ip_filename]
-      set ip_filename [extract_files -files [list "$ip_file_obj"] -base_dir "$tmp_dir"]
+      if { {} != $ip_file_obj } {
+        set ip_filename [extract_files -files [list "$ip_file_obj"] -base_dir "$tmp_dir"]
+      }
       if { ![file exists $ip_filename] } {
         send_msg_id SIM-utils-052 WARNING "IP component XML file does not exist: '$ip_filename'\n"
         continue;

--- a/tclapp/xilinx/ies/ies.tcl
+++ b/tclapp/xilinx/ies/ies.tcl
@@ -9,4 +9,4 @@ namespace eval ::tclapp::xilinx::ies {
     lappend ::auto_path $home
   }
 }
-package provide ::tclapp::xilinx::ies 3.41
+package provide ::tclapp::xilinx::ies 3.42

--- a/tclapp/xilinx/ies/pkgIndex.tcl
+++ b/tclapp/xilinx/ies/pkgIndex.tcl
@@ -8,4 +8,4 @@
 # script is sourced, the variable $dir must contain the
 # full path name of this file's directory.
 
-package ifneeded ::tclapp::xilinx::ies 3.41 [list source [file join $dir ies.tcl]]
+package ifneeded ::tclapp::xilinx::ies 3.42 [list source [file join $dir ies.tcl]]

--- a/tclapp/xilinx/ies/revision_history.txt
+++ b/tclapp/xilinx/ies/revision_history.txt
@@ -1,3 +1,4 @@
+3.42 check for empty source file object before extracting
 3.41 extract xml comp files for finding SV pkg libraries
 3.40 source user tcl file from wrapper generated in run directory
 3.39 fetch sv files in quiet mode as those may not be part of compile order

--- a/tclapp/xilinx/modelsim/app.xml
+++ b/tclapp/xilinx/modelsim/app.xml
@@ -2,7 +2,7 @@
 <catalog>
   <apps>
     <app>
-      <revision_history>extract xml comp files for finding SV pkg libraries</revision_history>
+      <revision_history>check for empty source file object before extracting</revision_history>
       <name>modelsim</name>
       <pkg_require>Vivado 2014.1</pkg_require>
       <company>xilinx</company>

--- a/tclapp/xilinx/modelsim/common/utils.tcl
+++ b/tclapp/xilinx/modelsim/common/utils.tcl
@@ -2328,7 +2328,9 @@ proc xcs_find_sv_pkg_libs { run_dir } {
     if { ![file exists $ip_filename] } {
       # extract files
       set ip_file_obj [get_files -all -quiet $ip_filename]
-      set ip_filename [extract_files -files [list "$ip_file_obj"] -base_dir "$tmp_dir"]
+      if { {} != $ip_file_obj } {
+        set ip_filename [extract_files -files [list "$ip_file_obj"] -base_dir "$tmp_dir"]
+      }
       if { ![file exists $ip_filename] } {
         send_msg_id SIM-utils-052 WARNING "IP component XML file does not exist: '$ip_filename'\n"
         continue;

--- a/tclapp/xilinx/modelsim/modelsim.tcl
+++ b/tclapp/xilinx/modelsim/modelsim.tcl
@@ -9,4 +9,4 @@ namespace eval ::tclapp::xilinx::modelsim {
     lappend ::auto_path $home
   }
 }
-package provide ::tclapp::xilinx::modelsim 2.151
+package provide ::tclapp::xilinx::modelsim 2.152

--- a/tclapp/xilinx/modelsim/pkgIndex.tcl
+++ b/tclapp/xilinx/modelsim/pkgIndex.tcl
@@ -8,4 +8,4 @@
 # script is sourced, the variable $dir must contain the
 # full path name of this file's directory.
 
-package ifneeded ::tclapp::xilinx::modelsim 2.151 [list source [file join $dir modelsim.tcl]]
+package ifneeded ::tclapp::xilinx::modelsim 2.152 [list source [file join $dir modelsim.tcl]]

--- a/tclapp/xilinx/modelsim/revision_history.txt
+++ b/tclapp/xilinx/modelsim/revision_history.txt
@@ -1,3 +1,4 @@
+2.152 check for empty source file object before extracting
 2.151 extract xml comp files for finding SV pkg libraries
 2.150 source user tcl file from wrapper generated in run directory
 2.149 fetch sv files in quiet mode as those may not be part of compile order

--- a/tclapp/xilinx/projutils/app.xml
+++ b/tclapp/xilinx/projutils/app.xml
@@ -2,7 +2,7 @@
 <catalog>
   <apps>
     <app>
-      <revision_history>fixed include_dirs property value to relative wrt origin dir and skip deprecated verilog_dir</revision_history>
+      <revision_history>check for empty source file object before extracting</revision_history>
       <name>projutils</name>
       <pkg_require>Vivado 2014.1</pkg_require>
       <company>xilinx</company>

--- a/tclapp/xilinx/projutils/common/utils.tcl
+++ b/tclapp/xilinx/projutils/common/utils.tcl
@@ -2328,7 +2328,9 @@ proc xcs_find_sv_pkg_libs { run_dir } {
     if { ![file exists $ip_filename] } {
       # extract files
       set ip_file_obj [get_files -all -quiet $ip_filename]
-      set ip_filename [extract_files -files [list "$ip_file_obj"] -base_dir "$tmp_dir"]
+      if { {} != $ip_file_obj } {
+        set ip_filename [extract_files -files [list "$ip_file_obj"] -base_dir "$tmp_dir"]
+      }
       if { ![file exists $ip_filename] } {
         send_msg_id SIM-utils-052 WARNING "IP component XML file does not exist: '$ip_filename'\n"
         continue;

--- a/tclapp/xilinx/projutils/pkgIndex.tcl
+++ b/tclapp/xilinx/projutils/pkgIndex.tcl
@@ -8,4 +8,4 @@
 # script is sourced, the variable $dir must contain the
 # full path name of this file's directory.
 
-package ifneeded ::tclapp::xilinx::projutils 3.230 [list source [file join $dir projutils.tcl]]
+package ifneeded ::tclapp::xilinx::projutils 3.231 [list source [file join $dir projutils.tcl]]

--- a/tclapp/xilinx/projutils/projutils.tcl
+++ b/tclapp/xilinx/projutils/projutils.tcl
@@ -9,4 +9,4 @@ namespace eval ::tclapp::xilinx::projutils {
     lappend ::auto_path $home
   }
 }
-package provide ::tclapp::xilinx::projutils 3.230
+package provide ::tclapp::xilinx::projutils 3.231

--- a/tclapp/xilinx/projutils/revision_history.txt
+++ b/tclapp/xilinx/projutils/revision_history.txt
@@ -1,3 +1,4 @@
+3.231 check for empty source file object before extracting
 3.230 fixed include_dirs property value to relative wrt origin dir and skip deprecated verilog_dir
 3.228 extract xml comp files for finding SV pkg libraries
 3.227 call get_files in quiet mode to hide warnings when project does not contain sources

--- a/tclapp/xilinx/questa/app.xml
+++ b/tclapp/xilinx/questa/app.xml
@@ -2,7 +2,7 @@
 <catalog>
   <apps>
     <app>
-      <revision_history>extract xml comp files for finding SV pkg libraries</revision_history>
+      <revision_history>check for empty source file object before extracting</revision_history>
       <name>questa</name>
       <pkg_require>Vivado 2014.1</pkg_require>
       <company>xilinx</company>

--- a/tclapp/xilinx/questa/common/utils.tcl
+++ b/tclapp/xilinx/questa/common/utils.tcl
@@ -2328,7 +2328,9 @@ proc xcs_find_sv_pkg_libs { run_dir } {
     if { ![file exists $ip_filename] } {
       # extract files
       set ip_file_obj [get_files -all -quiet $ip_filename]
-      set ip_filename [extract_files -files [list "$ip_file_obj"] -base_dir "$tmp_dir"]
+      if { {} != $ip_file_obj } {
+        set ip_filename [extract_files -files [list "$ip_file_obj"] -base_dir "$tmp_dir"]
+      }
       if { ![file exists $ip_filename] } {
         send_msg_id SIM-utils-052 WARNING "IP component XML file does not exist: '$ip_filename'\n"
         continue;

--- a/tclapp/xilinx/questa/pkgIndex.tcl
+++ b/tclapp/xilinx/questa/pkgIndex.tcl
@@ -8,4 +8,4 @@
 # script is sourced, the variable $dir must contain the
 # full path name of this file's directory.
 
-package ifneeded ::tclapp::xilinx::questa 2.42 [list source [file join $dir questa.tcl]]
+package ifneeded ::tclapp::xilinx::questa 2.43 [list source [file join $dir questa.tcl]]

--- a/tclapp/xilinx/questa/questa.tcl
+++ b/tclapp/xilinx/questa/questa.tcl
@@ -9,4 +9,4 @@ namespace eval ::tclapp::xilinx::questa {
     lappend ::auto_path $home
   }
 }
-package provide ::tclapp::xilinx::questa 2.42
+package provide ::tclapp::xilinx::questa 2.43

--- a/tclapp/xilinx/questa/revision_history.txt
+++ b/tclapp/xilinx/questa/revision_history.txt
@@ -1,3 +1,4 @@
+2.43 check for empty source file object before extracting
 2.42 extract xml comp files for finding SV pkg libraries
 2.41 source user tcl file from wrapper generated in run directory
 2.40 fetch sv files in quiet mode as those may not be part of compile order

--- a/tclapp/xilinx/vcs/app.xml
+++ b/tclapp/xilinx/vcs/app.xml
@@ -2,7 +2,7 @@
 <catalog>
   <apps>
     <app>
-      <revision_history>extract xml comp files for finding SV pkg libraries</revision_history>
+      <revision_history>check for empty source file object before extracting</revision_history>
       <name>vcs</name>
       <pkg_require>Vivado 2014.1</pkg_require>
       <company>xilinx</company>

--- a/tclapp/xilinx/vcs/common/utils.tcl
+++ b/tclapp/xilinx/vcs/common/utils.tcl
@@ -2328,7 +2328,9 @@ proc xcs_find_sv_pkg_libs { run_dir } {
     if { ![file exists $ip_filename] } {
       # extract files
       set ip_file_obj [get_files -all -quiet $ip_filename]
-      set ip_filename [extract_files -files [list "$ip_file_obj"] -base_dir "$tmp_dir"]
+      if { {} != $ip_file_obj } {
+        set ip_filename [extract_files -files [list "$ip_file_obj"] -base_dir "$tmp_dir"]
+      }
       if { ![file exists $ip_filename] } {
         send_msg_id SIM-utils-052 WARNING "IP component XML file does not exist: '$ip_filename'\n"
         continue;

--- a/tclapp/xilinx/vcs/pkgIndex.tcl
+++ b/tclapp/xilinx/vcs/pkgIndex.tcl
@@ -8,4 +8,4 @@
 # script is sourced, the variable $dir must contain the
 # full path name of this file's directory.
 
-package ifneeded ::tclapp::xilinx::vcs 3.43 [list source [file join $dir vcs.tcl]]
+package ifneeded ::tclapp::xilinx::vcs 3.44 [list source [file join $dir vcs.tcl]]

--- a/tclapp/xilinx/vcs/revision_history.txt
+++ b/tclapp/xilinx/vcs/revision_history.txt
@@ -1,3 +1,4 @@
+3.44 check for empty source file object before extracting
 3.43 extract xml comp files for finding SV pkg libraries
 3.42 source user tcl file from wrapper generated in run directory
 3.41 fetch sv files in quiet mode as those may not be part of compile order

--- a/tclapp/xilinx/vcs/vcs.tcl
+++ b/tclapp/xilinx/vcs/vcs.tcl
@@ -9,4 +9,4 @@ namespace eval ::tclapp::xilinx::vcs {
     lappend ::auto_path $home
   }
 }
-package provide ::tclapp::xilinx::vcs 3.43
+package provide ::tclapp::xilinx::vcs 3.44

--- a/tclapp/xilinx/xsim/app.xml
+++ b/tclapp/xilinx/xsim/app.xml
@@ -2,7 +2,7 @@
 <catalog>
   <apps>
     <app>
-      <revision_history>extract xml comp files for finding SV pkg libraries</revision_history>
+      <revision_history>check for empty source file object before extracting</revision_history>
       <name>xsim</name>
       <pkg_require>Vivado 2014.1</pkg_require>
       <company>xilinx</company>

--- a/tclapp/xilinx/xsim/common/utils.tcl
+++ b/tclapp/xilinx/xsim/common/utils.tcl
@@ -2328,7 +2328,9 @@ proc xcs_find_sv_pkg_libs { run_dir } {
     if { ![file exists $ip_filename] } {
       # extract files
       set ip_file_obj [get_files -all -quiet $ip_filename]
-      set ip_filename [extract_files -files [list "$ip_file_obj"] -base_dir "$tmp_dir"]
+      if { {} != $ip_file_obj } {
+        set ip_filename [extract_files -files [list "$ip_file_obj"] -base_dir "$tmp_dir"]
+      }
       if { ![file exists $ip_filename] } {
         send_msg_id SIM-utils-052 WARNING "IP component XML file does not exist: '$ip_filename'\n"
         continue;

--- a/tclapp/xilinx/xsim/pkgIndex.tcl
+++ b/tclapp/xilinx/xsim/pkgIndex.tcl
@@ -8,4 +8,4 @@
 # script is sourced, the variable $dir must contain the
 # full path name of this file's directory.
 
-package ifneeded ::tclapp::xilinx::xsim 2.153 [list source [file join $dir xsim.tcl]]
+package ifneeded ::tclapp::xilinx::xsim 2.154 [list source [file join $dir xsim.tcl]]

--- a/tclapp/xilinx/xsim/revision_history.txt
+++ b/tclapp/xilinx/xsim/revision_history.txt
@@ -1,3 +1,4 @@
+2.154 check for empty source file object before extracting
 2.153 extract xml comp files for finding SV pkg libraries
 2.152 source user tcl file from wrapper generated in run directory
 2.151 fetch sv files in quiet mode as those may not be part of compile order

--- a/tclapp/xilinx/xsim/xsim.tcl
+++ b/tclapp/xilinx/xsim/xsim.tcl
@@ -9,4 +9,4 @@ namespace eval ::tclapp::xilinx::xsim {
     lappend ::auto_path $home
   }
 }
-package provide ::tclapp::xilinx::xsim 2.153
+package provide ::tclapp::xilinx::xsim 2.154


### PR DESCRIPTION
cr:971539 - check for empty source file object before extracting

Please merge to master and update 2017.1 and 2017.2 catalogs (priority-p1), thanks
