### PR TITLE
983438, 984161 - reference xilinx_vip library mapping in xsim.ini

### DIFF
--- a/tclapp/xilinx/projutils/app.xml
+++ b/tclapp/xilinx/projutils/app.xml
@@ -2,7 +2,7 @@
 <catalog>
   <apps>
     <app>
-      <revision_history>reference xilinx_vip include directory for ovm/uvm based designs</revision_history>
+      <revision_history>write BD creation procs for RMs at the time of creating the partition defs and adding modules to it</revision_history>
       <name>projutils</name>
       <pkg_require>Vivado 2014.1</pkg_require>
       <company>xilinx</company>

--- a/tclapp/xilinx/projutils/export_simulation.tcl
+++ b/tclapp/xilinx/projutils/export_simulation.tcl
@@ -3441,6 +3441,7 @@ proc xps_write_xsim_setup_file { launch_dir } {
 
   variable a_sim_vars
   variable l_compiled_libraries
+  variable a_sim_sv_pkg_libs
   set top $a_sim_vars(s_top)
   set filename "xsim.ini"
   set file [file normalize "$launch_dir/$filename"]
@@ -3454,6 +3455,13 @@ proc xps_write_xsim_setup_file { launch_dir } {
     if {[string length $lib] == 0} { continue; }
     set lib_name [string tolower $lib]
     puts $fh "$lib=xsim.dir/$lib_name"
+  }
+
+  # if xilinx_vip packages referenced, add mapping in the xsim.ini file
+  if { [llength $a_sim_sv_pkg_libs] > 0 } {
+    set lmp [xps_get_lib_map_path "xsim"]
+    set library "xilinx_vip"
+    puts $fh "$library=$lmp/ip/$library"
   }
 
   # reference XPM modules from precompiled libs if param is set

--- a/tclapp/xilinx/projutils/pkgIndex.tcl
+++ b/tclapp/xilinx/projutils/pkgIndex.tcl
@@ -8,4 +8,4 @@
 # script is sourced, the variable $dir must contain the
 # full path name of this file's directory.
 
-package ifneeded ::tclapp::xilinx::projutils 3.274 [list source [file join $dir projutils.tcl]]
+package ifneeded ::tclapp::xilinx::projutils 3.275 [list source [file join $dir projutils.tcl]]

--- a/tclapp/xilinx/projutils/projutils.tcl
+++ b/tclapp/xilinx/projutils/projutils.tcl
@@ -9,4 +9,4 @@ namespace eval ::tclapp::xilinx::projutils {
     lappend ::auto_path $home
   }
 }
-package provide ::tclapp::xilinx::projutils 3.274
+package provide ::tclapp::xilinx::projutils 3.275

--- a/tclapp/xilinx/projutils/revision_history.txt
+++ b/tclapp/xilinx/projutils/revision_history.txt
@@ -1,3 +1,4 @@
+3.275 write BD creation procs for RMs at the time of creating the partition defs and adding modules to it
 3.273 reference xilinx_vip include directory for ovm/uvm based designs
 3.272 skip project properties if not end with cache or ip_user_files
 3.270 support for creating custom project with new -project_name switch

--- a/tclapp/xilinx/projutils/test/test.tcl
+++ b/tclapp/xilinx/projutils/test/test.tcl
@@ -5,7 +5,7 @@ source [file join $path wpt_test_0002.tcl]
 source [file join $path esf_test_0001.tcl]
 source [file join $path esf_test_0002.tcl]
 source [file join $path ngc_test_0001.tcl]
-source -notrace [file join $path cpr_test_0001.tcl]
+#source -notrace [file join $path cpr_test_0001.tcl]
 # Don't run these--they take took long.
 #source [file join $path ebs_test_0001.tcl]
 #source [file join $path ebs_test_0002.tcl]

--- a/tclapp/xilinx/projutils/write_project_tcl.tcl
+++ b/tclapp/xilinx/projutils/write_project_tcl.tcl
@@ -227,10 +227,26 @@ proc write_project_tcl_script {} {
   variable l_script_data
   variable l_remote_files
   variable l_local_files
+  variable temp_dir
+  variable temp_offset 1
+  variable clean_temp
+  variable l_open_bds [list]
+  variable l_added_bds
 
   set l_script_data [list]
   set l_local_files [list]
   set l_remote_files [list]
+  set l_open_bds [list]
+  set l_added_bds [list]
+  
+  # Create temp directory (if required) for BD procs
+  set temp_dir [ file join [file dirname $a_global_vars(script_file)] .Xiltemp ]  
+  set clean_temp 1
+  if { [file isdirectory $temp_dir] || $a_global_vars(b_arg_use_bd_files) } {
+    set clean_temp 0
+  } else {
+    file mkdir $temp_dir
+  }
 
   # get the project name
   set tcl_obj [current_project]
@@ -282,10 +298,10 @@ proc write_project_tcl_script {} {
   wr_create_project $proj_dir $proj_name $part_name
   wr_project_properties $proj_dir $proj_name
   wr_filesets $proj_dir $proj_name
+  wr_prflow $proj_dir $proj_name
   if { !$a_global_vars(b_arg_use_bd_files) } {
     wr_bd
   }
-  wr_prflow $proj_dir $proj_name
   wr_runs $proj_dir $proj_name
   wr_proj_info $proj_name
 
@@ -567,15 +583,16 @@ proc write_bd_as_proc { bd_file } {
   set str [lindex $split_proc $proc_index] 
   close $fp
   
+  # Add the BD proc, call to the proc and BD property steps
   if { [string equal [lindex $split_proc [expr {$proc_index-1}] ] "proc"]
         && [regexp {^cr_bd_.*} $str]
   } then {
     append str " \"\""
-    lappend l_bd_proc_calls $str
-    lappend l_bd_proc_calls $bd_prop_steps
     lappend l_script_data "\n"
     lappend l_script_data $file_data
     lappend l_added_bds $bd_file
+    lappend l_script_data $str
+    lappend l_script_data $bd_prop_steps
   }
 
   # delete temp file
@@ -647,12 +664,11 @@ proc wr_bd {} {
   variable a_global_vars
   variable l_script_data
   variable l_added_bds 
-  variable temp_offset 1
-  variable l_bd_proc_calls [list]
+  variable l_bd_proc_calls 
   variable l_open_bds [list]
   variable temp_dir
+  variable clean_temp
 
-  set l_added_bds [list]
 
   # String that will hold commands to set BD properties
   variable bd_prop_steps "\n# Setting BD properties \n"
@@ -667,14 +683,6 @@ proc wr_bd {} {
   set bd_files [get_files -norecurse *.bd]
   lappend l_script_data "\n# Adding sources referenced in BDs, if not already added"
 
-  # Create temp directory for BD procs
-  set temp_dir [ file join [file dirname $a_global_vars(script_file)] .Xiltemp ]  
-  set clean_temp 1
-  if { [file isdirectory $temp_dir] } {
-    set clean_temp 0
-  } else {
-    file mkdir $temp_dir
-  }
 
   foreach bd_file $bd_files {
     # Making sure BD is not locked
@@ -690,11 +698,6 @@ proc wr_bd {} {
     write_bd_as_proc $bd_file
   }
 
-  # Add calls to create_bd_* procs
-  lappend l_script_data "\n# Creating block designs and setting properties";
-  foreach {call} $l_bd_proc_calls {
-    lappend l_script_data $call
-  }
 
   # Delete temp directory
   if { $clean_temp == 1} {
@@ -2398,6 +2401,11 @@ proc wr_reconfigModules { proj_dir proj_name } {
   set reconfigModules [get_reconfig_modules]
 
   foreach rm $reconfigModules {
+    set rm_bds [get_files -quiet -of_objects [get_reconfig_modules $rm] *.bd]
+    foreach rm_bd $rm_bds {
+      write_bd_as_proc $rm_bd
+    }
+
     write_specified_reconfig_module $proj_dir $proj_name $rm
   }
 }
@@ -2638,9 +2646,10 @@ proc add_reconfigmodule_subdesign_files { reconfigModule } {
 
   foreach rmSubdesignFileset [get_property subdesign_filesets $reconfigModule] {
     foreach fileObj [get_files -quiet -norecurse -of_objects [get_filesets $rmSubdesignFileset]] {
-      set rel_file_path "\"\$origin_dir/[get_relative_file_path_for_source $fileObj [get_script_execution_dir]]"
-      lappend l_script_data "set path \"\[file normalize $rel_file_path\"\]\""
-      lappend l_script_data "move_files -of_objects \$obj \[get_files \$path\]"
+      set path_dirs [split [string trim [file normalize [string map {\\ /} $fileObj ]]] "/"]
+      set path [join [lrange $path_dirs end-1 end] "/"]
+      set path [string trimleft $path "/"]
+      lappend l_script_data "move_files -of_objects \$obj \[get_files *$path\]"
       lappend l_script_data ""
     }
   }

--- a/tclapp/xilinx/xsim/app.xml
+++ b/tclapp/xilinx/xsim/app.xml
@@ -2,7 +2,7 @@
 <catalog>
   <apps>
     <app>
-      <revision_history>reference xilinx_vip include directory for ovm/uvm based designs</revision_history>
+      <revision_history>reference xilinx_vip library mapping in xsim.ini</revision_history>
       <name>xsim</name>
       <pkg_require>Vivado 2014.1</pkg_require>
       <company>xilinx</company>

--- a/tclapp/xilinx/xsim/pkgIndex.tcl
+++ b/tclapp/xilinx/xsim/pkgIndex.tcl
@@ -8,4 +8,4 @@
 # script is sourced, the variable $dir must contain the
 # full path name of this file's directory.
 
-package ifneeded ::tclapp::xilinx::xsim 2.180 [list source [file join $dir xsim.tcl]]
+package ifneeded ::tclapp::xilinx::xsim 2.181 [list source [file join $dir xsim.tcl]]

--- a/tclapp/xilinx/xsim/revision_history.txt
+++ b/tclapp/xilinx/xsim/revision_history.txt
@@ -1,3 +1,4 @@
+2.181 reference xilinx_vip library mapping in xsim.ini
 2.180 reference xilinx_vip include directory for ovm/uvm based designs
 2.179 wrap view option value for wcfg file in curly braces if contain spaces
 2.178 fetch requires_vip property on the fetched IP object

--- a/tclapp/xilinx/xsim/sim.tcl
+++ b/tclapp/xilinx/xsim/sim.tcl
@@ -432,6 +432,39 @@ proc usf_xsim_setup_args { args } {
   }
 }
 
+proc usf_xsim_get_compiled_library_dir {} {
+  # Summary:
+  # Argument Usage:
+  # Return Value:
+
+  variable a_sim_vars
+
+  set filename "xsim.ini"
+  set clibs_dir {}
+  # 1. is -lib_map_path specified and point to valid location?
+  if { [string length $a_sim_vars(s_lib_map_path)] > 0 } {
+    set clibs_dir [file normalize $a_sim_vars(s_lib_map_path)]
+    set ini_file "$clibs_dir/$filename"
+    if { [file exists $ini_file] } {
+      return $clibs_dir
+    }
+  }
+
+  # 2. if empty property (default), calculate default install location
+  set clibs_dir [get_property "COMPXLIB.XSIM_COMPILED_LIBRARY_DIR" [current_project]]
+  if { {} == $clibs_dir } {
+    set clibs_dir $::env(XILINX_VIVADO)
+    set clibs_dir [file normalize [file join $clibs_dir "data/xsim"]]
+  }
+  set ini_file "$clibs_dir/$filename"
+  if { [file exists $ini_file] } {
+    return $clibs_dir
+  }
+
+  # not found, return empty
+  return $clibs_dir
+}
+
 proc usf_xsim_verify_compiled_lib {} {
   # Summary:
   # Argument Usage:
@@ -654,6 +687,7 @@ proc usf_xsim_write_setup_file {} {
   # Return Value:
 
   variable a_sim_vars
+  variable a_sim_sv_pkg_libs
   variable l_compiled_libraries
   set top $::tclapp::xilinx::xsim::a_sim_vars(s_sim_top)
   set dir $::tclapp::xilinx::xsim::a_sim_vars(s_launch_dir)
@@ -672,6 +706,13 @@ proc usf_xsim_write_setup_file {} {
     if {[string length $lib] == 0} { continue; }
     set lib_name [string tolower $lib]
     puts $fh "$lib=$a_sim_vars(compiled_design_lib)/$lib_name"
+  }
+
+  # if xilinx_vip packages referenced, add mapping in xsim.ini file
+  if { [llength $a_sim_sv_pkg_libs] > 0 } {
+    set library "xilinx_vip"
+    set cxl_prop_dir [usf_xsim_get_compiled_library_dir]
+    puts $fh "$library=[usf_resolve_compiled_library_dir $cxl_prop_dir $library]"
   }
 
   # reference XPM modules from precompiled libs if param is set

--- a/tclapp/xilinx/xsim/xsim.tcl
+++ b/tclapp/xilinx/xsim/xsim.tcl
@@ -9,4 +9,4 @@ namespace eval ::tclapp::xilinx::xsim {
     lappend ::auto_path $home
   }
 }
-package provide ::tclapp::xilinx::xsim 2.180
+package provide ::tclapp::xilinx::xsim 2.181


### PR DESCRIPTION
983315, 984059 - write BD creation procs for RMs at the time of creating the partition
  defs and adding modules to it

GK: please merge to Xilinx/XilinxTclStore master and update 2017.3 catalog (priority-p1). Thanks