### PR TITLE
 If the xilinx_vip library is in the use, it is included automaticall…

### DIFF
--- a/tclapp/aldec/activehdl/activehdl.tcl
+++ b/tclapp/aldec/activehdl/activehdl.tcl
@@ -12,4 +12,4 @@ namespace eval ::tclapp::aldec::activehdl {
     lappend ::auto_path $home
   }
 }
-package provide ::tclapp::aldec::activehdl 1.13
+package provide ::tclapp::aldec::activehdl 1.14

--- a/tclapp/aldec/activehdl/app.xml
+++ b/tclapp/aldec/activehdl/app.xml
@@ -2,7 +2,7 @@
 <catalog>
   <apps>
     <app>
-      <revision_history>Removed superfluous option for incremental compilation. Fixed generated paths in compilation and simulation scripts. Added handling of &apos;xilinx_vip&apos; library.</revision_history>
+      <revision_history>If the xilinx_vip library is in the use, it is included automatically in the compilation and simulation scripts.</revision_history>
       <name>activehdl</name>
       <pkg_require>Vivado 2014.1</pkg_require>
       <company>aldec</company>

--- a/tclapp/aldec/activehdl/common/helpers.tcl
+++ b/tclapp/aldec/activehdl/common/helpers.tcl
@@ -8,7 +8,7 @@
 
 package require Vivado 1.2014.1
 
-package provide ::tclapp::aldec::common::helpers 1.13
+package provide ::tclapp::aldec::common::helpers 1.14
 
 namespace eval ::tclapp::aldec::common {
 
@@ -3615,13 +3615,18 @@ proc vip_ips {} {
 }
 
 proc is_vip_ip_required {} {
-  if { [get_param project.usePreCompiledXilinxVIPLibForSim] } {
-    foreach ip_obj [get_ips -all -quiet] {
-      set ipdef [get_property -quiet IPDEF $ip_obj]
-      set ip_name [lindex [split $ipdef ":"] 2]
-      if { [lsearch -nocase [vip_ips] $ip_name] != -1 } {
-        return true
-      }
+  foreach ip_obj [get_ips -all -quiet] {
+    set requires_vip [get_property -quiet requires_vip $ip_obj]
+    if { $requires_vip } {
+      return true
+    }
+  }
+
+  foreach ip_obj [get_ips -all -quiet] {
+    set ipdef [get_property -quiet IPDEF $ip_obj]
+    set ip_name [lindex [split $ipdef ":"] 2]
+    if { [lsearch -nocase [vip_ips] $ip_name] != -1 } {
+      return true
     }
   }
   return false 

--- a/tclapp/aldec/activehdl/common/pkgIndex.tcl
+++ b/tclapp/aldec/activehdl/common/pkgIndex.tcl
@@ -8,5 +8,5 @@
 # script is sourced, the variable $dir must contain the
 # full path name of this file's directory.
 
-package ifneeded ::tclapp::aldec::common::helpers 1.13 [list source [file join $dir helpers.tcl]]
-package ifneeded ::tclapp::aldec::common::sim 1.13 [list source [file join $dir sim.tcl]]
+package ifneeded ::tclapp::aldec::common::helpers 1.14 [list source [file join $dir helpers.tcl]]
+package ifneeded ::tclapp::aldec::common::sim 1.14 [list source [file join $dir sim.tcl]]

--- a/tclapp/aldec/activehdl/common/sim.tcl
+++ b/tclapp/aldec/activehdl/common/sim.tcl
@@ -8,9 +8,9 @@
 
 package require Vivado 1.2014.1
 
-package require ::tclapp::aldec::common::helpers 1.13
+package require ::tclapp::aldec::common::helpers 1.14
 
-package provide ::tclapp::aldec::common::sim 1.13
+package provide ::tclapp::aldec::common::sim 1.14
 
 namespace eval ::tclapp::aldec::common {
 

--- a/tclapp/aldec/activehdl/pkgIndex.tcl
+++ b/tclapp/aldec/activehdl/pkgIndex.tcl
@@ -8,4 +8,4 @@
 # script is sourced, the variable $dir must contain the
 # full path name of this file's directory.
 
-package ifneeded ::tclapp::aldec::activehdl 1.13 [list source [file join $dir activehdl.tcl]]
+package ifneeded ::tclapp::aldec::activehdl 1.14 [list source [file join $dir activehdl.tcl]]

--- a/tclapp/aldec/activehdl/register_options.tcl
+++ b/tclapp/aldec/activehdl/register_options.tcl
@@ -8,7 +8,7 @@
 
 package require Vivado 1.2014.1
 
-package require ::tclapp::aldec::common::helpers 1.13
+package require ::tclapp::aldec::common::helpers 1.14
 
 namespace eval ::tclapp::aldec::activehdl {
 

--- a/tclapp/aldec/activehdl/revision_history.txt
+++ b/tclapp/aldec/activehdl/revision_history.txt
@@ -1,3 +1,4 @@
+1.14 If the xilinx_vip library is in the use, it is included automatically in the compilation and simulation scripts.
 1.13 Removed superfluous option for incremental compilation. Fixed generated paths in compilation and simulation scripts. Added handling of 'xilinx_vip' library.
 1.12 Generated scripts are now automatically made executable. List of libraries is now included in vlog command.
 1.11 Fixed bug with -scripts_only switch. Changed generated simulation script - now simulation works differently in batch mode. Removed fixed simulation resolution.

--- a/tclapp/aldec/activehdl/sim.tcl
+++ b/tclapp/aldec/activehdl/sim.tcl
@@ -8,8 +8,8 @@
 
 package require Vivado 1.2014.1
 
-package require ::tclapp::aldec::common::sim 1.13
-package require ::tclapp::aldec::common::helpers 1.13
+package require ::tclapp::aldec::common::sim 1.14
+package require ::tclapp::aldec::common::helpers 1.14
 
 namespace eval ::tclapp::aldec::activehdl {
 

--- a/tclapp/aldec/riviera/app.xml
+++ b/tclapp/aldec/riviera/app.xml
@@ -2,7 +2,7 @@
 <catalog>
   <apps>
     <app>
-      <revision_history>Removed superfluous option for incremental compilation. Fixed generated paths in compilation and simulation scripts. Added handling of &apos;xilinx_vip&apos; library.</revision_history>
+      <revision_history>If the xilinx_vip library is in the use, it is included automatically in the compilation and simulation scripts.</revision_history>
       <name>riviera</name>
       <pkg_require>Vivado 2014.1</pkg_require>
       <company>aldec</company>

--- a/tclapp/aldec/riviera/common/helpers.tcl
+++ b/tclapp/aldec/riviera/common/helpers.tcl
@@ -8,7 +8,7 @@
 
 package require Vivado 1.2014.1
 
-package provide ::tclapp::aldec::common::helpers 1.13
+package provide ::tclapp::aldec::common::helpers 1.14
 
 namespace eval ::tclapp::aldec::common {
 
@@ -3615,13 +3615,18 @@ proc vip_ips {} {
 }
 
 proc is_vip_ip_required {} {
-  if { [get_param project.usePreCompiledXilinxVIPLibForSim] } {
-    foreach ip_obj [get_ips -all -quiet] {
-      set ipdef [get_property -quiet IPDEF $ip_obj]
-      set ip_name [lindex [split $ipdef ":"] 2]
-      if { [lsearch -nocase [vip_ips] $ip_name] != -1 } {
-        return true
-      }
+  foreach ip_obj [get_ips -all -quiet] {
+    set requires_vip [get_property -quiet requires_vip $ip_obj]
+    if { $requires_vip } {
+      return true
+    }
+  }
+
+  foreach ip_obj [get_ips -all -quiet] {
+    set ipdef [get_property -quiet IPDEF $ip_obj]
+    set ip_name [lindex [split $ipdef ":"] 2]
+    if { [lsearch -nocase [vip_ips] $ip_name] != -1 } {
+      return true
     }
   }
   return false 

--- a/tclapp/aldec/riviera/common/pkgIndex.tcl
+++ b/tclapp/aldec/riviera/common/pkgIndex.tcl
@@ -8,5 +8,5 @@
 # script is sourced, the variable $dir must contain the
 # full path name of this file's directory.
 
-package ifneeded ::tclapp::aldec::common::helpers 1.13 [list source [file join $dir helpers.tcl]]
-package ifneeded ::tclapp::aldec::common::sim 1.13 [list source [file join $dir sim.tcl]]
+package ifneeded ::tclapp::aldec::common::helpers 1.14 [list source [file join $dir helpers.tcl]]
+package ifneeded ::tclapp::aldec::common::sim 1.14 [list source [file join $dir sim.tcl]]

--- a/tclapp/aldec/riviera/common/sim.tcl
+++ b/tclapp/aldec/riviera/common/sim.tcl
@@ -8,9 +8,9 @@
 
 package require Vivado 1.2014.1
 
-package require ::tclapp::aldec::common::helpers 1.13
+package require ::tclapp::aldec::common::helpers 1.14
 
-package provide ::tclapp::aldec::common::sim 1.13
+package provide ::tclapp::aldec::common::sim 1.14
 
 namespace eval ::tclapp::aldec::common {
 

--- a/tclapp/aldec/riviera/pkgIndex.tcl
+++ b/tclapp/aldec/riviera/pkgIndex.tcl
@@ -8,4 +8,4 @@
 # script is sourced, the variable $dir must contain the
 # full path name of this file's directory.
 
-package ifneeded ::tclapp::aldec::riviera 1.13 [list source [file join $dir riviera.tcl]]
+package ifneeded ::tclapp::aldec::riviera 1.14 [list source [file join $dir riviera.tcl]]

--- a/tclapp/aldec/riviera/register_options.tcl
+++ b/tclapp/aldec/riviera/register_options.tcl
@@ -8,7 +8,7 @@
 
 package require Vivado 1.2014.1
 
-package require ::tclapp::aldec::common::helpers 1.13
+package require ::tclapp::aldec::common::helpers 1.14
 
 namespace eval ::tclapp::aldec::riviera {
 

--- a/tclapp/aldec/riviera/revision_history.txt
+++ b/tclapp/aldec/riviera/revision_history.txt
@@ -1,3 +1,4 @@
+1.14 If the xilinx_vip library is in the use, it is included automatically in the compilation and simulation scripts.
 1.13 Removed superfluous option for incremental compilation. Fixed generated paths in compilation and simulation scripts. Added handling of 'xilinx_vip' library.
 1.12 Generated scripts are now automatically made executable. List of libraries is now included in vlog command.
 1.11 Fixed bug with -scripts_only switch. Changed generated simulation script - now simulation works differently in batch mode. Removed fixed simulation resolution.

--- a/tclapp/aldec/riviera/riviera.tcl
+++ b/tclapp/aldec/riviera/riviera.tcl
@@ -12,4 +12,4 @@ namespace eval ::tclapp::aldec::riviera {
     lappend ::auto_path $home
   }
 }
-package provide ::tclapp::aldec::riviera 1.13
+package provide ::tclapp::aldec::riviera 1.14

--- a/tclapp/aldec/riviera/sim.tcl
+++ b/tclapp/aldec/riviera/sim.tcl
@@ -8,8 +8,8 @@
 
 package require Vivado 1.2014.1
 
-package require ::tclapp::aldec::common::sim 1.13
-package require ::tclapp::aldec::common::helpers 1.13
+package require ::tclapp::aldec::common::sim 1.14
+package require ::tclapp::aldec::common::helpers 1.14
 
 namespace eval ::tclapp::aldec::riviera {
 


### PR DESCRIPTION
…y in the compilation and simulation scripts.

The fix is checked and approved by our SQA team.