### PR TITLE
Fix for testcase regression/features/tclstore/repo/xilinx/junit, Fixe…

### DIFF
--- a/tclapp/xilinx/junit/JUnitAssertionMgr.tcl
+++ b/tclapp/xilinx/junit/JUnitAssertionMgr.tcl
@@ -356,7 +356,7 @@ proc validate_drcs { { _group "ValidateDRCs" } } {
 
   # DRCs: RunAllDRCs
   set testcase [ new_testcase $results $testsuite "RunAllDRCs" $_group ]
-  reset_drc
+  # reset_drc
   set failureMsg [ report_drc -return_string ]
   set cmd "get_drc_violations -quiet"
   if { [ llength [ run_silent $cmd ] ] > 0 } {
@@ -382,7 +382,7 @@ proc validate_logic { { _group "ValidateLogic" } } {
   # Synthesis: DriverlessNetsDRC
   set testcase [ new_testcase $results $testsuite "DriverlessNetsDRC" $_group ]
   set rule "NDRV-1"
-  reset_drc
+  # reset_drc
   set cmd "report_drc -checks $rule -return_string"
   set failureMsg [ run_silent $cmd ]
   set violations [ llength [ get_drc_violations -quiet ${rule}* ] ] 


### PR DESCRIPTION
Fix for testcase regression/features/tclstore/repo/xilinx/junit, Fixed JUnitAssertionMgr.tcl, reset_drc no longer supports resetting all the drc without a valid name