### PR TITLE
Updated JUnitAssertionMgr.tcl

### DIFF
--- a/tclapp/xilinx/junit/JUnitAssertionMgr.tcl
+++ b/tclapp/xilinx/junit/JUnitAssertionMgr.tcl
@@ -356,7 +356,7 @@ proc validate_drcs { { _group "ValidateDRCs" } } {
 
   # DRCs: RunAllDRCs
   set testcase [ new_testcase $results $testsuite "RunAllDRCs" $_group ]
-  reset_drc
+  # reset_drc
   set failureMsg [ report_drc -return_string ]
   set cmd "get_drc_violations -quiet"
   if { [ llength [ run_silent $cmd ] ] > 0 } {
@@ -382,7 +382,7 @@ proc validate_logic { { _group "ValidateLogic" } } {
   # Synthesis: DriverlessNetsDRC
   set testcase [ new_testcase $results $testsuite "DriverlessNetsDRC" $_group ]
   set rule "NDRV-1"
-  reset_drc
+  # reset_drc
   set cmd "report_drc -checks $rule -return_string"
   set failureMsg [ run_silent $cmd ]
   set violations [ llength [ get_drc_violations -quiet ${rule}* ] ] 

--- a/tclapp/xilinx/junit/junit.tcl
+++ b/tclapp/xilinx/junit/junit.tcl
@@ -12,4 +12,4 @@ namespace eval ::tclapp::xilinx::junit {
 
 }
 
-package provide ::tclapp::xilinx::junit 1.0
+package provide ::tclapp::xilinx::junit 1.1

--- a/tclapp/xilinx/junit/pkgIndex.tcl
+++ b/tclapp/xilinx/junit/pkgIndex.tcl
@@ -8,4 +8,4 @@
 # script is sourced, the variable $dir must contain the
 # full path name of this file's directory.
 
-package ifneeded ::tclapp::xilinx::junit 1.0 [list source [file join $dir junit.tcl]]
+package ifneeded ::tclapp::xilinx::junit 1.1 [list source [file join $dir junit.tcl]]


### PR DESCRIPTION
Updated JUnitAssertionMgr.tcl, reset_drc no longer supports resetting all the drc without a valid name, should fix tclapp/xilinx/junit/test.  