### PR TITLE
Added support for US+ -1LV/-2LV (xilinx::designutils::report_failfast)

### DIFF
--- a/tclapp/xilinx/designutils/app.xml
+++ b/tclapp/xilinx/designutils/app.xml
@@ -2,7 +2,7 @@
 <catalog>
   <apps>
     <app>
-      <revision_history>Added support for newer architectures (report_failfast, get_sll_nets, get_sll_nodes). Major enhancements (prettyTable)</revision_history>
+      <revision_history>Added support for US+ -1LV/-2LV (report_failfast)</revision_history>
       <name>designutils</name>
       <pkg_require>Vivado 2014.1</pkg_require>
       <company>xilinx</company>

--- a/tclapp/xilinx/designutils/designutils.tcl
+++ b/tclapp/xilinx/designutils/designutils.tcl
@@ -11,4 +11,4 @@ namespace eval ::tclapp::xilinx::designutils {
 
 }
 
-package provide ::tclapp::xilinx::designutils 1.41
+package provide ::tclapp::xilinx::designutils 1.42

--- a/tclapp/xilinx/designutils/pkgIndex.tcl
+++ b/tclapp/xilinx/designutils/pkgIndex.tcl
@@ -8,4 +8,4 @@
 # script is sourced, the variable $dir must contain the
 # full path name of this file's directory.
 
-package ifneeded ::tclapp::xilinx::designutils 1.41 [list source [file join $dir designutils.tcl]]
+package ifneeded ::tclapp::xilinx::designutils 1.42 [list source [file join $dir designutils.tcl]]

--- a/tclapp/xilinx/designutils/report_failfast.tcl
+++ b/tclapp/xilinx/designutils/report_failfast.tcl
@@ -5,6 +5,7 @@ namespace eval ::tclapp::xilinx::designutils {
 }
 
 ########################################################################################
+## 2019.01.10 - Added support for US+ -1LV/-2LV
 ## 2018.11.16 - Added support for spartan7, zynquplusRFSOC, virtexuplus58g
 ##              and virtexuplusHBM
 ## 2018.05.11 - Fixed check for empty name for -cell/-pblock/-slr
@@ -326,7 +327,7 @@ set help_message [format {
 # Trick to silence the linter
 eval [list namespace eval ::tclapp::xilinx::designutils::report_failfast {
   namespace export report_failfast
-  variable version {2018.11.16}
+  variable version {2019.01.10}
   variable script [info script]
   variable SUITE_INTEGRATION 0
   variable params
@@ -2110,9 +2111,19 @@ proc ::tclapp::xilinx::designutils::report_failfast::report_failfast {args} {
         virtexuplusHBM -
         zynquplusRFSOC {
           switch -regexp -- $speedgrade {
+            "-1.*LV.*" {
+              # US+ -1LV == US -1
+              set timBudgetPerLUT 0.490
+              set timBudgetPerNet 0.342
+            }
             "-1.*" {
               set timBudgetPerLUT 0.350
               set timBudgetPerNet 0.239
+            }
+            "-2.*LV.*" {
+              # US+ -2LV == US -2
+              set timBudgetPerLUT 0.425
+              set timBudgetPerNet 0.298
             }
             "-2.*" {
               set timBudgetPerLUT 0.300

--- a/tclapp/xilinx/designutils/revision_history.txt
+++ b/tclapp/xilinx/designutils/revision_history.txt
@@ -1,3 +1,4 @@
+1.42 Added support for US+ -1LV/-2LV (report_failfast)
 1.41 Added support for newer architectures (report_failfast, get_sll_nets, get_sll_nodes). Major enhancements (prettyTable)
 1.40 Fixed issue (report_failfast). Various enhancements (prettyTable)
 1.39 Various enhancements (prettyTable)

--- a/tclapp/xilinx/designutils/tclIndex
+++ b/tclapp/xilinx/designutils/tclIndex
@@ -6,7 +6,6 @@
 # element name is the name of a command and the value is
 # a script that loads the command.
 
-
 set auto_index(::tclapp::xilinx::designutils::bisect_pblock) [list source [file join $dir bisect_pblock.tcl]]
 set auto_index(::tclapp::xilinx::designutils::check_cdc_paths) [list source [file join $dir check_cdc_paths.tcl]]
 set auto_index(::tclapp::xilinx::designutils::clone_cell) [list source [file join $dir replicate_high_fanout_registers.tcl]]


### PR DESCRIPTION
Pull request for designutils for 2018.3 (master branch)