### PR TITLE
Not to allow write_project_tcl command creating empty filename .tcl

### DIFF
--- a/tclapp/xilinx/projutils/pkgIndex.tcl
+++ b/tclapp/xilinx/projutils/pkgIndex.tcl
@@ -8,4 +8,4 @@
 # script is sourced, the variable $dir must contain the
 # full path name of this file's directory.
 
-package ifneeded ::tclapp::xilinx::projutils 3.429 [list source [file join $dir projutils.tcl]]
+package ifneeded ::tclapp::xilinx::projutils 3.430 [list source [file join $dir projutils.tcl]]

--- a/tclapp/xilinx/projutils/projutils.tcl
+++ b/tclapp/xilinx/projutils/projutils.tcl
@@ -9,4 +9,4 @@ namespace eval ::tclapp::xilinx::projutils {
     lappend ::auto_path $home
   }
 }
-package provide ::tclapp::xilinx::projutils 3.429
+package provide ::tclapp::xilinx::projutils 3.430

--- a/tclapp/xilinx/projutils/write_project_tcl.tcl
+++ b/tclapp/xilinx/projutils/write_project_tcl.tcl
@@ -107,7 +107,7 @@ proc write_project_tcl {args} {
   }
  
   # script file is a must
-  if { [string equal $a_global_vars(script_file) ""] } {
+  if { [lsearch {"" ".tcl"} [file tail $a_global_vars(script_file)]] != -1 } {
     if { $a_global_vars(b_arg_quiet) } {
       reset_msg_setting
     }


### PR DESCRIPTION
Fix the issue, write_project_tcl creates empty .tcl files