### PR TITLE
Updating refclock summary for reporting paranet IP information properly:2023.1

### DIFF
--- a/tclapp/xilinx/designutils/report_gt_refclk_summary.tcl
+++ b/tclapp/xilinx/designutils/report_gt_refclk_summary.tcl
@@ -606,13 +606,26 @@ proc ::tclapp::xilinx::designutils::report_gt_refclk_summary::not_empty_int {obj
 }
 
 proc ::tclapp::xilinx::designutils::report_gt_refclk_summary::compare_dict {dict1 dict2} {
+	# summary:
+	# proc compares two different discts which give as inputs arguments
+	
+	# Argument Usage:
+
+    # Return Value:
+	# null ("") if dicts detected as same. false (0) otherwise
+	
+    # Categories: Xilinxtclstore, projutils
+
 	set val1 [list ]
 	set val2 [list ]
+	# check if the size is same. if yes proceed else return "0"
 	if {[dict size $dict1] == [dict size $dict2]} {
 		foreach key [dict keys $dict1] {
+			#check whether key from dict1 exsist in dict2. if yes proceed else return "0"
 			if {[dict exists $dict2 $key]} {
 				set val1 [lsort [dict get $dict1 $key]]
 				set val2 [lsort [dict get $dict2 $key]]
+				#compare values for the key from both dict. if yes proceed else return "0"
 				if {$val1 != $val2} {
 					return 0
 				} 

--- a/tclapp/xilinx/designutils/report_gt_refclk_summary.tcl
+++ b/tclapp/xilinx/designutils/report_gt_refclk_summary.tcl
@@ -22,6 +22,8 @@ namespace eval ::tclapp::xilinx::designutils {
 ##   Vivado% xilinx::designutils::report_gt_refclk_summary
 ##   2021.05.05 - Initial release
 ##   2023.02.21 - updated script to report error message while parameter propagation is wrong.
+##   2023.03.08 - Updated script to populate data on information form quad. And script will compare the data from quad and interface just 
+##                to confirm whether parameter propagation is correct or wrong, and prints messages accordingly
 ##
 ##
 ##########################################################################################################
@@ -250,6 +252,18 @@ set bd_dk [current_bd_design]
 		  set idx [lsearch $keys_lsk "unconnected"]
 		  set keys_lsk_updated [lreplace $keys_lsk $idx $idx]
           set prot_num [llength $keys_lsk]
+
+          set LANE_SEL_DICT_QUAD ""
+		  set LANE_SEL_DICT_QUAD [dict create]
+          dict lappend LANE_SEL_DICT_QUAD [get_property CONFIG.RX0_LANE_SEL [get_bd_cells $quadCell]] RX0
+          dict lappend LANE_SEL_DICT_QUAD [get_property CONFIG.RX1_LANE_SEL [get_bd_cells $quadCell]] RX1
+          dict lappend LANE_SEL_DICT_QUAD [get_property CONFIG.RX2_LANE_SEL [get_bd_cells $quadCell]] RX2
+          dict lappend LANE_SEL_DICT_QUAD [get_property CONFIG.RX3_LANE_SEL [get_bd_cells $quadCell]] RX3
+          dict lappend LANE_SEL_DICT_QUAD [get_property CONFIG.TX0_LANE_SEL [get_bd_cells $quadCell]] TX0
+          dict lappend LANE_SEL_DICT_QUAD [get_property CONFIG.TX1_LANE_SEL [get_bd_cells $quadCell]] TX1
+          dict lappend LANE_SEL_DICT_QUAD [get_property CONFIG.TX2_LANE_SEL [get_bd_cells $quadCell]] TX2
+          dict lappend LANE_SEL_DICT_QUAD [get_property CONFIG.TX3_LANE_SEL [get_bd_cells $quadCell]] TX3
+
           set ref_clk_d [get_property CONFIG.REFCLK_STRING [get_bd_cells ${quadCell}]]
           set REFCLK_EXTERNAL_CONNECT                    [dict values $ref_clk_d]
           set REFCLK_EXTERNAL_CONNECT_UNIQUE             [uniquify_list $REFCLK_EXTERNAL_CONNECT]
@@ -297,14 +311,19 @@ set bd_dk [current_bd_design]
               } else {
                   set prot_val "PROT7"
               }
-			  if {[dict exists $LANE_SEL_DICT $prot_val] } { 
-              set lkey [dict get $LANE_SEL_DICT $prot_val]
+			  if {[dict exists $LANE_SEL_DICT_QUAD $prot_val] } { 
+              set lkey [dict get $LANE_SEL_DICT_QUAD $prot_val]
 			  set lkeya [split $lkey " "]
                set lkeya1 [lindex $lkeya 0]
                set lkeyf "$quadCell\/$lkeya1\_GT_IP_INTERFACE"
                set pCellName [find_connected_core $lkeyf]
 	           } 
-               lappend list_AK0 $pCellName
+		      if {$pCellName != {}} {
+                 lappend list_AK0 $pCellName
+		      } else {
+                 lappend list_AK0 ""
+			  }
+
               set multi_found 1
            } else {
 		   set prot_val [string map {"\_unique6" ""} [string map {"\_unique5" ""} [string map {"\_unique4" ""} [string map {"\_unique3" ""} [string map {"\_unique2" ""} [string map {"\_unique1" ""} [string map {"\_MHz" ""} [string map {"refclk_" ""} [string map {"R0_" ""} [string map {"R1_" ""} [string map {"R2_" ""} [string map {"R3_" ""} [string map {"R4_" ""} [string map {"R5_" ""} $temp ]]]]]]]]]]]]]] 
@@ -357,15 +376,17 @@ set bd_dk [current_bd_design]
                set prot_src_info2 $ikk
                set prot_src_sp1 [split $prot_src_info2 ","]
                set prot_src_info [lindex $prot_src_sp1 0]
-			   if {[dict exists $LANE_SEL_DICT $prot_src_info]} { 
-               set lkey [dict get $LANE_SEL_DICT $prot_src_info]
+			   if {[dict exists $LANE_SEL_DICT_QUAD $prot_src_info]} { 
+               set lkey [dict get $LANE_SEL_DICT_QUAD $prot_src_info]
                set lkeya [split $lkey " "]
                set lkeya [lsort -unique $lkeya]
 
                set lkeya1 [lindex $lkeya 0]
                set lkeyf "$quadCell\/$lkeya1\_GT_IP_INTERFACE"
                set pCellName [find_connected_core $lkeyf]
-               lappend pCellName1 $pCellName
+               if {$pCellName != {}} {
+				   lappend pCellName1 $pCellName
+			   }
                set pCellName1 [lsort -unique $pCellName1]
                if {$num_parIP > 1} {
                  set pCellName [join $pCellName1 ","]
@@ -382,14 +403,17 @@ set bd_dk [current_bd_design]
           $tbl1 addrow $list_AK0
 	 } 
 		  set prot_val_merged [concat $port_val_multi_uniq $prot_val_list_uniq]
+		  set prot_val_merged_uniq [lsort -unique $prot_val_merged] 
 
-       		 if {$keys_lsk_updated == $prot_val_merged} {
-       			 set statement_flag 0
-                } else {
-       		     set statement_flag 1
+		 set dict_equal [compare_dict $LANE_SEL_DICT $LANE_SEL_DICT_QUAD] 
+
+       		 if {$dict_equal == 0} {
+				 set statement_flag 1
        		     set statement "Unable to find any valid Interface Properties for Quad $quadCell. Refclk frequencies may not be reported correctly for this quad."
        			 lappend statement_list $statement
                  set unique_statement [lsort -unique $statement_list]
+                } else {
+       			 set statement_flag 0
              }
         }
         }
@@ -400,7 +424,8 @@ set bd_dk [current_bd_design]
 		   puts $outfilek " $sentence"
 	     }
         puts $outfilek "  "
-		puts $outfilek " Interface Properties are propagated from Parent IP to the GT quad. Please ensure that the Parent IP or the connected Interface is packaged to host the properties. Also please refer summary.log file for each quad in project for the reference clock information"
+		puts $outfilek " Interface Properties are propagated from Parent IP to the GT quad. Please ensure that the Parent IP or the connected Interface is packaged to host the properties."
+	    puts $outfilek " Also please refer summary.log file for each quad in project for the reference clock information."
      	}
         puts $outfilek "  "
         puts $outfilek [$tbl1 print]
@@ -579,6 +604,27 @@ proc ::tclapp::xilinx::designutils::report_gt_refclk_summary::not_empty_int {obj
     return 0
   }
 }
+
+proc ::tclapp::xilinx::designutils::report_gt_refclk_summary::compare_dict {dict1 dict2} {
+	set val1 [list ]
+	set val2 [list ]
+	if {[dict size $dict1] == [dict size $dict2]} {
+		foreach key [dict keys $dict1] {
+			if {[dict exists $dict2 $key]} {
+				set val1 [lsort [dict get $dict1 $key]]
+				set val2 [lsort [dict get $dict2 $key]]
+				if {$val1 != $val2} {
+					return 0
+				} 
+			} else {
+				return 0
+			}
+		}
+	} else {
+		return 0
+	}
+}
+
 
 proc ::tclapp::xilinx::designutils::report_gt_refclk_summary::evaluate_bd_properties { tx0Handle tx1Handle tx2Handle tx3Handle rx0Handle rx1Handle rx2Handle rx3Handle } {
   # Summary:

--- a/tclapp/xilinx/designutils/report_gt_refclk_summary.tcl
+++ b/tclapp/xilinx/designutils/report_gt_refclk_summary.tcl
@@ -195,11 +195,11 @@ set bd_dk [current_bd_design]
 		  set unique_statement [list ]	  
 		  set port_val_multi_uniq    [list ]
 		  set prot_val_list_uniq [list ]
+          set numq 0
         foreach quadCell $quadList {
           set gt_t [get_property CONFIG.GT_TYPE -quiet [get_bd_cells ${quadCell}]]
           set txIntfcs [list ]
           set rxIntfcs [list ]
-          set numq 0
           set txIntfcPIDs [list ]
           set rxIntfcPIDs [list ]
           set txc 0
@@ -424,8 +424,8 @@ set bd_dk [current_bd_design]
 		   puts $outfilek " $sentence"
 	     }
         puts $outfilek "  "
-		puts $outfilek " Interface Properties are propagated from Parent IP to the GT quad. Please ensure that the Parent IP or the connected Interface is packaged to host the properties."
-	    puts $outfilek " Also please refer summary.log file for each quad in project for the reference clock information."
+		puts $outfilek "Note:      Interface Properties are propagated from Parent IP to the GT quad. Please ensure that the Parent IP or the connected Interface is packaged to host the properties."
+	    puts $outfilek "           Also please refer summary.log file for each quad in project for the reference clock information."
      	}
         puts $outfilek "  "
         puts $outfilek [$tbl1 print]


### PR DESCRIPTION
updated refclock summary report, to populate data based on parameter values from quad. Also compares the quad details with interface data and finds out whether parameter propagation is correct or not. 
generates print statements accordingly.