### PR TITLE
Enhancements to report_io_reg.tcl script

### DIFF
--- a/tclapp/xilinx/ultrafast/app.xml
+++ b/tclapp/xilinx/ultrafast/app.xml
@@ -2,7 +2,7 @@
 <catalog>
   <apps>
     <app>
-      <revision_history>Minor cleanup</revision_history>
+      <revision_history>Added support for Spartan UltraScale+ and Versal devices; switched to node-traversal approach for UltraScale/UltraScale+ (report_io_reg)</revision_history>
       <name>ultrafast</name>
       <pkg_require>Vivado 2014.1</pkg_require>
       <company>xilinx</company>

--- a/tclapp/xilinx/ultrafast/checklist_pkg.tcl
+++ b/tclapp/xilinx/ultrafast/checklist_pkg.tcl
@@ -11,5 +11,5 @@ namespace eval ::tclapp::xilinx::ultrafast {
 
 }
 
-package provide ::tclapp::xilinx::ultrafast 1.10
+package provide ::tclapp::xilinx::ultrafast 1.11
 

--- a/tclapp/xilinx/ultrafast/pkgIndex.tcl
+++ b/tclapp/xilinx/ultrafast/pkgIndex.tcl
@@ -8,4 +8,4 @@
 # script is sourced, the variable $dir must contain the
 # full path name of this file's directory.
 
-package ifneeded ::tclapp::xilinx::ultrafast 1.10 [list source [file join $dir checklist_pkg.tcl]]
+package ifneeded ::tclapp::xilinx::ultrafast 1.11 [list source [file join $dir checklist_pkg.tcl]]

--- a/tclapp/xilinx/ultrafast/report_io_reg.tcl
+++ b/tclapp/xilinx/ultrafast/report_io_reg.tcl
@@ -1,5 +1,6 @@
 
 ########################################################################################
+## 07/30/2026 - Replaced the coordinate-based approach with node traversal for UltraScale and UltraScale+ devices. Added support for Spartan UltraScale+ and Versal devices (German Nersisyan)
 ## 04/12/2019 - Added support for KU+, VU+, RFSOC, HBM, 58G
 ## 01/23/2015 - Added support for Native mode for UltraScale
 ## 01/22/2015 - Added support for UltraScale
@@ -161,7 +162,10 @@ proc ::tclapp::xilinx::ultrafast::report_io_reg::report_io_reg { args } {
     virtexu -
     virtexuplus -
     virtexuplus58g -
-    virtexuplusHBM {
+    virtexuplusHBM -
+    spartanuplus {
+    }
+    versal {
     }
     default {
       puts " -E- architecture $architecture is not supported."
@@ -174,7 +178,7 @@ proc ::tclapp::xilinx::ultrafast::report_io_reg::report_io_reg { args } {
   }
 
   set table [[namespace parent]::Table::Create {IO Ports Summary}]
-  $table header [list {Port} {Dir} {Coord} {Package pin} {IO Bank} {Clock Region} {IDELAY} {ODELAY} {ILOGIC} {OLOGIC} {Info}]
+  $table header [list {Port} {Dir} {Coord} {Package pin} {IO Bank} {Clock Region} {IDELAY} {ODELAY} {ILOGIC} {OLOGIC} {TLOGIC} {Info}]
 
   set output [list]
   set noOFF 0
@@ -197,12 +201,17 @@ proc ::tclapp::xilinx::ultrafast::report_io_reg::report_io_reg { args } {
 #       set tileloc [get_property LOC $port]
       set coord [string range $tileloc [string last "_" $tileloc]+1 end]
 
+      set buf [get_cells -quiet -of [get_nets -quiet -of [get_ports $port]]]
+      set bufpins [get_pins -hierarchical -filter "NAME=~$buf/*"]
+      set iologicsite {}
+
       # Determine if anything has been instantiated in the IDELAY block in the same
       # tile region
       set idelay_used {}
       set odelay_used {}
       set ilogic_used {}
       set ologic_used {}
+      set tlogic_used {}
       switch $architecture {
         artix7 -
         spartan7 -
@@ -221,19 +230,47 @@ proc ::tclapp::xilinx::ultrafast::report_io_reg::report_io_reg { args } {
         virtexu -
         virtexuplus -
         virtexuplus58g -
-        virtexuplusHBM {
-          # Support for both Component/Native modes
-          set idelay_used [get_cells -quiet -of [concat [get_bels -quiet "BITSLICE_RX_TX_$coord/IDELAY"] \
-                                                        [get_bels -quiet "BITSLICE_RX_TX_$coord/RX_BITSLICE"] \
-                                                        [get_bels -quiet "BITSLICE_RX_TX_$coord/RXTX_BITSLICE"] ]]
-          set odelay_used [get_cells -quiet -of [concat [get_bels -quiet "BITSLICE_RX_TX_$coord/ODELAY"] \
-                                                        [get_bels -quiet "BITSLICE_RX_TX_$coord/TX_BITSLICE"] \
-                                                        [get_bels -quiet "BITSLICE_RX_TX_$coord/TX_BITSLICE_TRI"] \
-                                                        [get_bels -quiet "BITSLICE_RX_TX_$coord/RXTX_BITSLICE"] ]]
-#           set idelay_used [get_cells -quiet -of [get_bels -quiet "BITSLICE_RX_TX_$coord/IDELAY"]]
-#           set odelay_used [get_cells -quiet -of [get_bels -quiet "BITSLICE_RX_TX_$coord/ODELAY"]]
-          set ilogic_used [get_cells -quiet -of [get_bels -quiet "BITSLICE_RX_TX_$coord/IN_FF"]]
-          set ologic_used [get_cells -quiet -of [get_bels -quiet "BITSLICE_RX_TX_$coord/OUT_FF"]]
+        virtexuplusHBM -
+	spartanuplus {
+          foreach traversedir {-uphill -downhill} {
+             set iologicsite [get_sites -quiet -of [get_site_pins -quiet -of [get_nodes -quiet $traversedir -of [get_nodes -quiet -of [get_site_pins -quiet -of $bufpins]]]] -filter {NAME=~*IOLOGIC* || NAME=~*BITSLICE*}]
+             if {$iologicsite != {}} { break }
+          }
+
+	  set idelay_used [get_cells -quiet -of [concat [get_bels -quiet "$iologicsite/IDELAY"] \
+                                                        [get_bels -quiet "$iologicsite/RX_BITSLICE"] \
+                                                        [get_bels -quiet "$iologicsite/RXTX_BITSLICE"] ]]
+          set odelay_used [get_cells -quiet -of [concat [get_bels -quiet "$iologicsite/ODELAY"] \
+                                                        [get_bels -quiet "$iologicsite/TX_BITSLICE"] \
+                                                        [get_bels -quiet "$iologicsite/TX_BITSLICE_TRI"] \
+                                                        [get_bels -quiet "$iologicsite/RXTX_BITSLICE"] ]]
+          set ilogic_used [get_cells -quiet -of [concat [get_bels -quiet "$iologicsite/IN_FF"] \
+	                                                [get_bels -quiet "$iologicsite/IPFF"]]]
+          set ologic_used [get_cells -quiet -of [concat [get_bels -quiet "$iologicsite/OUT_FF"] \
+	                                                [get_bels -quiet "$iologicsite/OPFF"]]]
+	  set tlogic_used [get_cells -quiet -of [get_bels -quiet "$iologicsite/TFF"]]
+	}
+	versal {
+          foreach traversedir {-uphill -downhill} {
+	     set iologicsite [concat [get_sites -quiet -of [get_site_pins -quiet -of [get_nodes -quiet $traversedir -of [get_nodes -quiet $traversedir -of [get_nodes -quiet $traversedir -of [get_nodes -quiet $traversedir -of [get_nodes -quiet $traversedir -of [get_nodes -quiet -of [get_site_pins -quiet -of $bufpins]]]]]]] -filter {NAME=~*IOLOGIC*}]] \
+			             [get_sites -quiet -of [get_site_pins -quiet -of [get_nodes -quiet $traversedir -of [get_nodes -quiet $traversedir -of [get_nodes -quiet -of [get_site_pins -quiet -of $bufpins]]]]] -filter {NAME=~*IOLOGIC*}]]
+             if {$iologicsite != {}} { break }
+          }
+          
+	  set beltypefull [get_property TYPE [get_bels -quiet -of $buf]]
+          set beltype [string range $beltypefull [expr {[string last "_" $beltypefull] + 1}] end]
+
+	  if {$beltype=="M"} {
+		set beltypems MASTER 
+          } elseif {$beltype=="S"} {
+		set beltypems SLAVE
+          }
+
+          set idelay_used [get_cells -quiet -of [get_bels -quiet "$iologicsite/IDELAY_$beltypems"]]
+          set odelay_used [get_cells -quiet -of [get_bels -quiet "$iologicsite/ODELAY_$beltypems"]]
+          set ilogic_used [get_cells -quiet -of [get_bels -quiet "$iologicsite/IPFF_$beltypems"]]
+          set ologic_used [get_cells -quiet -of [get_bels -quiet "$iologicsite/OPFF_$beltypems"]]
+	  set tlogic_used [get_cells -quiet -of [get_bels -quiet "$iologicsite/TFF_$beltypems"]]
         }
       }
 
@@ -251,9 +288,9 @@ proc ::tclapp::xilinx::ultrafast::report_io_reg::report_io_reg { args } {
       }
 
       if {$verbose} {
-        $table addrow [list $port $dir $coord $pp $bank $CR $idelay_used $odelay_used $ilogic_used $ologic_used $info]
+        $table addrow [list $port $dir $coord $pp $bank $CR $idelay_used $odelay_used $ilogic_used $ologic_used $tlogic_used $info]
       } else {
-        $table addrow [list $port $dir $coord $pp $bank $CR [llength $idelay_used] [llength $odelay_used] [llength $ilogic_used] [llength $ologic_used] $info ]
+        $table addrow [list $port $dir $coord $pp $bank $CR [llength $idelay_used] [llength $odelay_used] [llength $ilogic_used] [llength $ologic_used] [llength $tlogic_used] $info]
       }
 
     } else {
@@ -264,7 +301,7 @@ proc ::tclapp::xilinx::ultrafast::report_io_reg::report_io_reg { args } {
       set tileloc [get_sites -quiet -of_object $pp]
 #       set tileloc [get_property LOC $port]
       set coord [string range $tileloc [string last "_" $tileloc]+1 end]
-      $table addrow [list $port $dir $coord $pp $bank {} {} {} {} {} {Unconnected}]
+      $table addrow [list $port $dir $coord $pp $bank {} {} {} {} {} {} {Unconnected}]
       incr noUnconnected
     }
   }

--- a/tclapp/xilinx/ultrafast/revision_history.txt
+++ b/tclapp/xilinx/ultrafast/revision_history.txt
@@ -1,3 +1,4 @@
+1.11 Added support for Spartan UltraScale+ and Versal devices; switched to node-traversal approach for UltraScale/UltraScale+ (report_io_reg)
 1.10 Minor cleanup
 1.9 Improved memory requirement for large reports (report_reset_signals)
 1.8 Added support for KU+, VU+, RFSOC, HBM, 58G (report_io_reg)

--- a/tclapp/xilinx/ultrafast/test/report_io_reg_0001.test
+++ b/tclapp/xilinx/ultrafast/test/report_io_reg_0001.test
@@ -83,30 +83,30 @@ tcltest::test report_io_reg--results-ok {Check command output against expected r
   return 0
 } -cleanup {
 } -match glob \
--output {* +--------------------------------------------------------------------------------------------------------------+
- | IO Ports Summary                                                                                             |
- +-------+-----+-------+-------------+---------+--------------+--------+--------+--------+--------+-------------+
- | Port  | Dir | Coord | Package pin | IO Bank | Clock Region | IDELAY | ODELAY | ILOGIC | OLOGIC | Info        |
- +-------+-----+-------+-------------+---------+--------------+--------+--------+--------+--------+-------------+
- | clk   | IN  |       |             |         |              |        |        |        |        | Unconnected |
- | in1   | IN  |       |             |         |              |        |        |        |        | Unconnected |
- | in2   | IN  |       |             |         |              |        |        |        |        | Unconnected |
- | in3   | IN  |       |             |         |              |        |        |        |        | Unconnected |
- | in4   | IN  |       |             |         |              |        |        |        |        | Unconnected |
- | in5   | IN  |       |             |         |              |        |        |        |        | Unconnected |
- | in6   | IN  |       |             |         |              |        |        |        |        | Unconnected |
- | in7   | IN  |       |             |         |              |        |        |        |        | Unconnected |
- | in8   | IN  |       |             |         |              |        |        |        |        | Unconnected |
- | in9   | IN  |       |             |         |              |        |        |        |        | Unconnected |
- | out1  | OUT |       |             |         |              |        |        |        |        | Unconnected |
- | out2  | OUT |       |             |         |              |        |        |        |        | Unconnected |
- | out3  | OUT |       |             |         |              |        |        |        |        | Unconnected |
- | out4  | OUT |       |             |         |              |        |        |        |        | Unconnected |
- | out5  | OUT |       |             |         |              |        |        |        |        | Unconnected |
- | out6  | OUT |       |             |         |              |        |        |        |        | Unconnected |
- | reset | IN  |       |             |         |              |        |        |        |        | Unconnected |
- | sel   | IN  |       |             |         |              |        |        |        |        | Unconnected |
- +-------+-----+-------+-------------+---------+--------------+--------+--------+--------+--------+-------------+
+-output {* +-----------------------------------------------------------------------------------------------------------------------+
+ | IO Ports Summary                                                                                                      |
+ +-------+-----+-------+-------------+---------+--------------+--------+--------+--------+--------+--------+-------------+
+ | Port  | Dir | Coord | Package pin | IO Bank | Clock Region | IDELAY | ODELAY | ILOGIC | OLOGIC | TLOGIC | Info        |
+ +-------+-----+-------+-------------+---------+--------------+--------+--------+--------+--------+--------+-------------+
+ | clk   | IN  |       |             |         |              |        |        |        |        |        | Unconnected |
+ | in1   | IN  |       |             |         |              |        |        |        |        |        | Unconnected |
+ | in2   | IN  |       |             |         |              |        |        |        |        |        | Unconnected |
+ | in3   | IN  |       |             |         |              |        |        |        |        |        | Unconnected |
+ | in4   | IN  |       |             |         |              |        |        |        |        |        | Unconnected |
+ | in5   | IN  |       |             |         |              |        |        |        |        |        | Unconnected |
+ | in6   | IN  |       |             |         |              |        |        |        |        |        | Unconnected |
+ | in7   | IN  |       |             |         |              |        |        |        |        |        | Unconnected |
+ | in8   | IN  |       |             |         |              |        |        |        |        |        | Unconnected |
+ | in9   | IN  |       |             |         |              |        |        |        |        |        | Unconnected |
+ | out1  | OUT |       |             |         |              |        |        |        |        |        | Unconnected |
+ | out2  | OUT |       |             |         |              |        |        |        |        |        | Unconnected |
+ | out3  | OUT |       |             |         |              |        |        |        |        |        | Unconnected |
+ | out4  | OUT |       |             |         |              |        |        |        |        |        | Unconnected |
+ | out5  | OUT |       |             |         |              |        |        |        |        |        | Unconnected |
+ | out6  | OUT |       |             |         |              |        |        |        |        |        | Unconnected |
+ | reset | IN  |       |             |         |              |        |        |        |        |        | Unconnected |
+ | sel   | IN  |       |             |         |              |        |        |        |        |        | Unconnected |
+ +-------+-----+-------+-------------+---------+--------------+--------+--------+--------+--------+--------+-------------+
 
  # Ports with no Input FF: 0
  # Ports with no Output FF: 0


### PR DESCRIPTION
- Replaced the coordinate-based IOLOGIC/BITSLICE lookup with node-traversal (via `get_nodes`/`get_site_pins`) for UltraScale and UltraScale+ devices
- Added support for **Spartan UltraScale+** and **Versal** devices
- Added a new `TLOGIC` (tristate) column to the report table
- Updated report_io_reg_0001.test fixture for the new TLOGIC column