### PR TITLE
Fix tclapp::install junit failure in appinit sandbox pass

### DIFF
--- a/tclapp/xilinx/junit/JUnitAssertionMgr.tcl
+++ b/tclapp/xilinx/junit/JUnitAssertionMgr.tcl
@@ -891,7 +891,10 @@ proc init {} {
    
   variable results
   #if { "[ info command $results ]" == "$results" } { return }
-  set time [ clock format [ clock seconds ] -format "%Y-%m-%dT%H:%M:%S" ] 
+  # catch: clock format needs msgcat, which appinit's app-probe sandbox stubs out
+  if { [ catch { clock format [ clock seconds ] -format "%Y-%m-%dT%H:%M:%S" } time ] } {
+    set time ""
+  }
   set hostname [ info hostname ]
   new_results $results 
   set testsuites [ new_testsuites $results ]


### PR DESCRIPTION
Fixes #823 

## Problem
`tclapp::install junit` fails with:

    unknown namespace in import pattern "::msgcat::mcload"

## Root cause
`appinit::load_app` probes an app for its exported procs by sourcing its files in a throwaway interpreter where `package require` is stubbed to a no-op. `JUnitAssertionMgr.tcl`'s `init` proc runs at module load time and calls `clock format`, which lazily sources Tcl's `clock.tcl` and needs `msgcat`. Since `package require` is stubbed in that interpreter, `msgcat` never actually loads there, so `namespace import ::msgcat::mcload` fails.

That probe interpreter is discarded right after collecting the exported proc names, so nothing computed in `init` during that pass is actually used.

## Fix
Guard the `clock format` call with `catch`, falling back to an empty timestamp on failure. Harmless during the probe pass (result is discarded); the real load path (via `junit.tcl`'s package mechanism, unstubbed) is unaffected.

## Testing
- Reproduced the exact reported error on Vivado 2026.1 (`tclapp::install junit`)
- Confirmed the fix resolves it on the same Vivado 2026.1 install
- Root cause isolated and verified in a minimal standalone Tcl 8.6 reproduction of appinit's sandbox pattern